### PR TITLE
Fixed RPCBaseErrors import

### DIFF
--- a/gramjs_generator/generators/errors.js
+++ b/gramjs_generator/generators/errors.js
@@ -22,7 +22,7 @@ const generateErrors = (errors, f) => {
     }
 
     // Imports and new subclass creation
-    f.write(`const { RPCError, ${[...importBase.values()].join(', ')} } = require('./rpcbaseerrors');`)
+    f.write(`const { RPCError, ${[...importBase.values()].join(', ')} } = require('./RPCBaseErrors');`)
 
     f.write('\nconst format = require(\'string-format\');')
 


### PR DESCRIPTION
This fixes the issue with importing rpcbaseerrors on linux, since paths are case sensitive