### PR TITLE
Fix '\u0000\u0000' with Buffer.concat

### DIFF
--- a/gramjs/network/connection/TCPAbridged.js
+++ b/gramjs/network/connection/TCPAbridged.js
@@ -17,10 +17,6 @@ class AbridgedPacketCodec extends PacketCodec {
         if (length < 127) {
             length = struct.pack('B', length)
         } else {
-            // here we get a string '\u0000\u0000', because here is '+', not Buffer.concat([..., ...])
-            // length = Buffer.from('7f', 'hex') + readBufferFromBigInt(BigInt(length), 3)
-
-            // fix
             length = Buffer.concat([Buffer.from('7f', 'hex'), readBufferFromBigInt(BigInt(length), 3)])
         }
         return Buffer.concat([length, data])

--- a/gramjs/network/connection/TCPAbridged.js
+++ b/gramjs/network/connection/TCPAbridged.js
@@ -17,7 +17,11 @@ class AbridgedPacketCodec extends PacketCodec {
         if (length < 127) {
             length = struct.pack('B', length)
         } else {
-            length = Buffer.from('7f', 'hex') + readBufferFromBigInt(BigInt(length), 3)
+            // here we get a string '\u0000\u0000', because here is '+', not Buffer.concat([..., ...])
+            // length = Buffer.from('7f', 'hex') + readBufferFromBigInt(BigInt(length), 3)
+
+            // fix
+            length = Buffer.concat([Buffer.from('7f', 'hex'), readBufferFromBigInt(BigInt(length), 3)])
         }
         return Buffer.concat([length, data])
     }


### PR DESCRIPTION
The problem appears when sending a message, because "+" is used when Buffer.concat() is needed