### PR TITLE
Updated the typo in the example code to correctly call the gramjs.sessions object

### DIFF
--- a/examples/simpleLogin.js
+++ b/examples/simpleLogin.js
@@ -55,7 +55,7 @@ function codeCallback() {
 
 
 const { TelegramClient } = gramjs
-const { StringSession } = gramjs.session
+const { StringSession } = gramjs.sessions
 const apiId = process.env.APP_ID // put your api id here [for example 123456789]
 const apiHash = process.env.APP_HASH // put your api hash here [for example '123456abcfghe']
 


### PR DESCRIPTION
There was an error in the example code which was not allowing users to be able to get the sample code up and running, mainly because the `gramjs` variable contained `sessions` and not `session`. 

I have updated the code to reflect this.

We have also discussed this in #45 with @painor.