### PR TITLE
Fix webpack error.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "os-browserify": "^0.3.0",
     "pako": "^2.0.3",
     "path-browserify": "^1.0.1",
+    "process": "^0.11.10",
     "store2": "^2.12.0",
     "ts-mixer": "^5.4.0",
     "websocket": "^1.0.33"

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -32,7 +32,11 @@ module.exports = {
             'path': require.resolve("path-browserify") ,
             'net': false,
             'crypto': false,
-            "os": require.resolve("os-browserify/browser")
+            "os": require.resolve("os-browserify/browser"),
+            "util": false,
+            "assert": false,
+            "stream": false,
+            "constants": false
         },
     },
     mode: 'development',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -43,7 +43,10 @@ module.exports = {
     plugins: [
         new webpack.ProvidePlugin({
             Buffer: ['buffer', 'Buffer'],
-        })
+        }),
+        new webpack.ProvidePlugin({
+            process: 'process/browser',
+        }),
     ],
 
     output: {


### PR DESCRIPTION
Hi, I'm new here trying use gramjs to create a webpage telegram applications.
While I face the following error when I run `npx webpack` because of the version conflict.

```=sh
> npx webpack
assets by path ../dist/tl/ 14.1 KiB
  assets by path ../dist/tl/custom/*.ts 10.6 KiB 11 assets
  assets by path ../dist/tl/core/*.ts 1.99 KiB 5 assets
  assets by path ../dist/tl/*.ts 1.48 KiB 4 assets
assets by path ../dist/client/*.ts 13.1 KiB 16 assets
assets by path ../dist/network/ 18.4 KiB
  assets by path ../dist/network/*.ts 14.5 KiB 6 assets
  assets by path ../dist/network/connection/*.ts 3.92 KiB 5 assets
assets by path ../dist/extensions/*.ts 6.52 KiB 9 assets
assets by path ../dist/crypto/*.ts 4.34 KiB 8 assets
assets by path ../dist/*.ts 11.1 KiB 7 assets
assets by path ../dist/sessions/*.ts 6.18 KiB 5 assets
assets by path ../dist/errors/*.ts 5.63 KiB 4 assets
asset gramjs.js 1.55 MiB [emitted] (name: main)
asset ../dist/events/common.d.ts 403 bytes [emitted]
runtime modules 1010 bytes 5 modules
modules by path ./gramjs/ 830 KiB 72 modules
modules by path ./node_modules/ 605 KiB
  javascript modules 464 KiB 42 modules
  json modules 141 KiB
    ./node_modules/mime-db/db.json 139 KiB [built] [code generated]
    ./node_modules/websocket/package.json 1.79 KiB [built] [code generated]
crypto (ignored) 15 bytes [built] [code generated]
fs (ignored) 15 bytes [built] [code generated]
net (ignored) 15 bytes [built] [code generated]

ERROR in ./node_modules/graceful-fs/graceful-fs.js 6:11-26
Module not found: Error: Can't resolve 'util' in '/Users/eason/codes/AI_Chatbot/gramjs/node_modules/graceful-fs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
	- install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "util": false }
 @ ./node_modules/node-localstorage/node_modules/write-file-atomic/index.js 6:9-31
 @ ./node_modules/node-localstorage/LocalStorage.js 13:14-47
 @ ./gramjs/sessions/StoreSession.ts 19:28-56
 @ ./gramjs/sessions/index.ts 8:21-46
 @ ./gramjs/index.ts 36:30-51

ERROR in ./node_modules/graceful-fs/graceful-fs.js 83:6-29
Module not found: Error: Can't resolve 'assert' in '/Users/eason/codes/AI_Chatbot/gramjs/node_modules/graceful-fs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "assert": require.resolve("assert/") }'
	- install 'assert'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "assert": false }
 @ ./node_modules/node-localstorage/node_modules/write-file-atomic/index.js 6:9-31
 @ ./node_modules/node-localstorage/LocalStorage.js 13:14-47
 @ ./gramjs/sessions/StoreSession.ts 19:28-56
 @ ./gramjs/sessions/index.ts 8:21-46
 @ ./gramjs/index.ts 36:30-51

ERROR in ./node_modules/graceful-fs/legacy-streams.js 1:13-37
Module not found: Error: Can't resolve 'stream' in '/Users/eason/codes/AI_Chatbot/gramjs/node_modules/graceful-fs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "stream": require.resolve("stream-browserify") }'
	- install 'stream-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "stream": false }
 @ ./node_modules/graceful-fs/graceful-fs.js 3:13-43
 @ ./node_modules/node-localstorage/node_modules/write-file-atomic/index.js 6:9-31
 @ ./node_modules/node-localstorage/LocalStorage.js 13:14-47
 @ ./gramjs/sessions/StoreSession.ts 19:28-56
 @ ./gramjs/sessions/index.ts 8:21-46
 @ ./gramjs/index.ts 36:30-51

ERROR in ./node_modules/graceful-fs/polyfills.js 1:16-36
Module not found: Error: Can't resolve 'constants' in '/Users/eason/codes/AI_Chatbot/gramjs/node_modules/graceful-fs'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "constants": require.resolve("constants-browserify") }'
	- install 'constants-browserify'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "constants": false }
 @ ./node_modules/graceful-fs/graceful-fs.js 2:16-41
 @ ./node_modules/node-localstorage/node_modules/write-file-atomic/index.js 6:9-31
 @ ./node_modules/node-localstorage/LocalStorage.js 13:14-47
 @ ./gramjs/sessions/StoreSession.ts 19:28-56
 @ ./gramjs/sessions/index.ts 8:21-46
 @ ./gramjs/index.ts 36:30-51

ERROR in ./node_modules/node-localstorage/node_modules/write-file-atomic/index.js 9:30-53
Module not found: Error: Can't resolve 'util' in '/Users/eason/codes/AI_Chatbot/gramjs/node_modules/node-localstorage/node_modules/write-file-atomic'

BREAKING CHANGE: webpack < 5 used to include polyfills for node.js core modules by default.
This is no longer the case. Verify if you need this module and configure a polyfill for it.

If you want to include a polyfill, you need to:
	- add a fallback 'resolve.fallback: { "util": require.resolve("util/") }'
	- install 'util'
If you don't want to include a polyfill, you can use an empty module like this:
	resolve.fallback: { "util": false }
 @ ./node_modules/node-localstorage/LocalStorage.js 13:14-47
 @ ./gramjs/sessions/StoreSession.ts 19:28-56
 @ ./gramjs/sessions/index.ts 8:21-46
 @ ./gramjs/index.ts 36:30-51

5 errors have detailed information that is not shown.
Use 'stats.errorDetails: true' resp. '--stats-error-details' to show it.

webpack 5.21.2 compiled with 5 errors in 10252 ms
```

And I fix it following the instructions in the error in the commit `fix error for webpack`

After that, I face another error when open simpleLogin.html at webserver.

```
Uncaught ReferenceError: process is not defined
    at eval (polyfills.js:3)
    at Object../node_modules/graceful-fs/polyfills.js (gramjs.js:399)
    at __webpack_require__ (gramjs.js:1940)
    at eval (graceful-fs.js:2)
    at Object../node_modules/graceful-fs/graceful-fs.js (gramjs.js:379)
    at __webpack_require__ (gramjs.js:1940)
    at eval (index.js:8)
    at Object../node_modules/node-localstorage/node_modules/write-file-atomic/index.js (gramjs.js:592)
    at __webpack_require__ (gramjs.js:1940)
    at Object.eval (LocalStorage.js:13)
```

Therefore, I fix this by adding these lines in webpack.config.js. And install process as node_modules.

```
        }),
        new webpack.ProvidePlugin({
            process: 'process/browser',
        }),
```

All errors is clear. It can use Bot's token to connect by simpleLogin.html now!

To sum up, this PR will help users to webpack it directly after clone without the errors I just meet.