### PR TITLE
Fix return type of save method of Session: StringSession.save returns string

### DIFF
--- a/gramjs/sessions/Abstract.ts
+++ b/gramjs/sessions/Abstract.ts
@@ -133,7 +133,7 @@ export abstract class Session {
      * called whenever important properties change. It should
      * make persist the relevant session information to disk.
      */
-    abstract save(): void | string;
+    abstract save(): void;
 
     /**
      * Called upon client.log_out(). Should delete the stored

--- a/gramjs/sessions/Abstract.ts
+++ b/gramjs/sessions/Abstract.ts
@@ -133,7 +133,7 @@ export abstract class Session {
      * called whenever important properties change. It should
      * make persist the relevant session information to disk.
      */
-    abstract save(): void;
+    abstract save(): void | string;
 
     /**
      * Called upon client.log_out(). Should delete the stored

--- a/gramjs/sessions/StringSession.ts
+++ b/gramjs/sessions/StringSession.ts
@@ -78,7 +78,7 @@ export class StringSession extends MemorySession {
         }
     }
 
-    save() {
+    save(): string {
         if (!this.authKey || !this.serverAddress || !this.port) {
             return "";
         }


### PR DESCRIPTION
This fixes TypeScript errors when trying to use the result of `client.session.save` as string, for example: `Type 'void' is not assignable to type 'string'`.