### PR TITLE
Make password optional in UserAuthParams

### DIFF
--- a/gramjs/client/auth.ts
+++ b/gramjs/client/auth.ts
@@ -17,7 +17,7 @@ export interface UserAuthParams {
     phoneCode: (isCodeViaApp?: boolean) => Promise<string>;
     /** optional string or callback that should return the 2FA password if present.<br/>
      *  the password hint will be sent in the hint param */
-    password: (hint?: string) => Promise<string>;
+    password?: (hint?: string) => Promise<string>;
     /** in case of a new account creation this callback should return a first name and last name `[first,last]`. */
     firstAndLastNames?: () => Promise<[string, string?]>;
     /** a qrCode token for login through qrCode.<br/>


### PR DESCRIPTION
I am getting the following errors when I do not provide a password to the TelegramClient when authenticating as a user:
```
src/lib/telegram.ts:78:22 - error TS2345: Argument of type '{ phoneNumber: string; phoneCode: () => Promise<string>; onError: (err: Error) => void; }' is not assignable to parameter of type 'UserAuthParams | BotAuthParams'.
  Property 'password' is missing in type '{ phoneNumber: string; phoneCode: () => Promise<string>; onError: (err: Error) => void; }' but required in type 'UserAuthParams'.
```

Below is my code:
```typescript
const client = new TelegramClient(stringSession, creds.apiId, creds.apiHash, { connectionRetries: 2 });
await client.start({
  phoneNumber: creds.phone,
  phoneCode: async () => authCode(),
  onError: (err) => handleConnectionErr(err),
});
```

Per [this line](https://github.com/gram-js/gramjs/blob/master/gramjs/client/auth.ts#L18) shouldn't `password` be optional? If so, here is a PR to make it so. If it is not actually optional, can it be set to `string` so that I can pass it an empty string?
```typescript
phoneCode: string | (isCodeViaApp?: boolean) => Promise<string>;
``` 