### PR TITLE
Fix for TypeError: client._getInputDialog is not a function

### DIFF
--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -1174,6 +1174,11 @@ export class TelegramClient extends TelegramBaseClient {
         return userMethods._getInputDialog(this, peer);
     }
 
+    /** @hidden */
+    _getInputNotify(notify: any) {
+        return userMethods._getInputNotify(this, notify);
+    }
+
     //endregion
 
     //region base methods

--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -1169,6 +1169,11 @@ export class TelegramClient extends TelegramBaseClient {
         return userMethods.getPeerId(this, peer, addMark);
     }
 
+    /** @hidden */
+    _getInputDialog(peer: any) {
+        return userMethods._getInputDialog(this, peer);
+    }
+
     //endregion
 
     //region base methods


### PR DESCRIPTION
Fix for missing method in TelegramClient.

```
TypeError: client._getInputDialog is not a function
    at getInputFromResolve (/.../node_modules/telegram/tl/api.js:125:33)
    at VirtualClass.resolve (/.../node_modules/telegram/tl/api.js:468:49)
    at Object.invoke (/.../node_modules/telegram/client/users.js:22:19)
    at TelegramClient.invoke (/.../node_modules/telegram/client/TelegramClient.js:856:28)
```

Sample code to reproduce bug:     
```js
const dialogs = await tg.invoke(new Api.messages.GetPeerDialogs({
  peers: [peer]
}));
```

Maybe do something similar to `_getInputNotify` as well?