### PR TITLE
Improve Webpack configuration

### DIFF
--- a/examples/simpleLogin.html
+++ b/examples/simpleLogin.html
@@ -34,7 +34,7 @@
       </div>
     </form>
   </body>
-  <script src="../browser/gramjs.js"></script>
+  <script src="../browser/telegram.js"></script>
   <!--Loading the library-->
   <script src="betterLogging.js"></script>
   <!--beautifies the ouput (this rewrites console.log)-->

--- a/examples/simpleLogin.js
+++ b/examples/simpleLogin.js
@@ -51,8 +51,8 @@ function codeCallback() {
   });
 }
 
-const { TelegramClient } = gramjs;
-const { StringSession } = gramjs.sessions;
+const { TelegramClient } = telegram;
+const { StringSession } = telegram.sessions;
 const apiId = 1; // put your api id here [for example 123456789]
 const apiHash = "1  "; // put your api hash here [for example '123456abcfghe']
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,7 +19,6 @@ module.exports = {
       },
     ],
   },
-
   resolve: {
     extensions: [".tsx", ".ts", ".js"],
     fallback: {
@@ -34,7 +33,7 @@ module.exports = {
       constants: false,
     },
   },
-  mode: "development",
+  mode: process.env.NODE_ENV ?? "development",
   plugins: [
     new webpack.ProvidePlugin({
       Buffer: ["buffer", "Buffer"],
@@ -43,12 +42,10 @@ module.exports = {
       process: "process/browser",
     }),
   ],
-
   output: {
-    library: "gramjs",
+    library: "telegram",
     libraryTarget: "umd",
-    auxiliaryComment: "Test Comment",
-    filename: "gramjs.js",
+    filename: "telegram.js",
     path: path.resolve(__dirname, "browser"),
   },
 };


### PR DESCRIPTION
- Get `mode` from env or go with `development`.
- Set `output.library` to `telegram` to match with package name in npm.
- Remove `output.auxiliaryComment` as it is not required.
- Set `output.filename` to `telegram.js` for better readability.