### PR TITLE
refactor: editMessage convenient function

### DIFF
--- a/gramjs/Utils.ts
+++ b/gramjs/Utils.ts
@@ -821,7 +821,7 @@ export function getInputMedia(
         videoNote = false,
         supportsStreaming = false,
     }: GetInputMediaInterface = {}
-): any {
+): Api.TypeInputMedia {
     if (media.SUBCLASS_OF_ID === undefined) {
         _raiseCastFail(media, "InputMedia");
     }

--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -555,7 +555,7 @@ export interface EditMessageParams {
     linkPreview?: boolean;
     /** The file object that should replace the existing media in the message. */
     file?: FileLike;
-    /** thumbnail to be edited. */
+    /** Whether to send the given file as a document or not. */
     forceDocument?: false;
     /** The matrix (list of lists), row list or button to be shown after sending the message.<br/>
      *  This parameter will only work if you have signed in as a bot. You can also pass your own ReplyMarkup here.<br/>


### PR DESCRIPTION
Made some changes to editMessage function:

- Edit message method now support media
- Add handler for when `message` property of `EditMessageParams` is of type `Api.Message`
- Change `file` property type of `EditMessageParams` from `FileLike | Filelike[]` to `FileLike` because `Api.messages.EditMessage` only takes one media, not an array
- Add return type of `getInputMedia` in `Utils` from return any to return `Api.TypeInputMedia`