### PR TITLE
refactor: editMessage method of client

### DIFF
--- a/gramjs/Utils.ts
+++ b/gramjs/Utils.ts
@@ -821,7 +821,7 @@ export function getInputMedia(
         videoNote = false,
         supportsStreaming = false,
     }: GetInputMediaInterface = {}
-): any {
+): Api.TypeInputMedia {
     if (media.SUBCLASS_OF_ID === undefined) {
         _raiseCastFail(media, "InputMedia");
     }

--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -716,10 +716,11 @@ export class TelegramClient extends TelegramBaseClient {
      *  Used to edit a message by changing it's text or media
      *  message refers to the message to be edited not what to edit
      *  text refers to the new text
-     *  See also Message.edit()
+     *  See also Message.edit()<br/>
+     *  Notes: It is not possible to edit the media of a message that doesn't contain media.
      *  @param entity - From which chat to edit the message.<br/>
      *  This can also be the message to be edited, and the entity will be inferred from it, so the next parameter will be assumed to be the message text.<br/>
-     *  You may also pass a InputBotInlineMessageID, which is the only way to edit messages that were sent after the user selects an inline query result.
+     *  You may also pass a InputBotInlineMessageID, which is the only way to edit messages that were sent after the user selects an inline query result. Not supported yet!
      *  @param editMessageParams - see {@link EditMessageParams}.
      *  @return The edited Message.
      *  @throws

--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -776,6 +776,72 @@ export class TelegramClient extends TelegramBaseClient {
         });
     }
 
+    /**
+     * Pins a message in a chat.
+     *
+     * See also {@link Message.pin}`.
+     *
+     * @remarks The default behavior is to **not** notify members, unlike the official applications.
+     * @param entity - The chat where the message should be pinned.
+     * @param message - The message or the message ID to pin. If it's `undefined`, all messages will be unpinned instead.
+     * @param pinMessageParams - see {@link UpdatePinMessageParams}.
+     * @return
+     * The pinned message. if message is undefined the return will be {@link AffectedHistory}
+     * @example
+     *  ```ts
+     *  const message = await client.sendMessage(chat, 'GramJS is awesome!');
+     *
+     *  await client.pinMessage(chat, message);
+     *  ```
+     */
+    pinMessage(
+        entity: EntityLike,
+        message?: MessageIDLike,
+        pinMessageParams?: messageMethods.UpdatePinMessageParams
+    ) {
+        return messageMethods.pinMessage(
+            this,
+            entity,
+            message,
+            pinMessageParams
+        );
+    }
+
+    /**
+     * Unpins a message in a chat.
+     *
+     * See also {@link Message.unpin}`.
+     *
+     * @remarks The default behavior is to **not** notify members, unlike the official applications.
+     * @param entity - The chat where the message should be pinned.
+     * @param message - The message or the message ID to pin. If it's `undefined`, all messages will be unpinned instead.
+     * @param pinMessageParams - see {@link UpdatePinMessageParams}.
+     * @return
+     * The pinned message. if message is undefined the return will be {@link AffectedHistory}
+     * @example
+     *  ```ts
+     *  const message = await client.sendMessage(chat, 'GramJS is awesome!');
+     *
+     *  // unpin one message
+     *  await client.unpinMessage(chat, message);
+     *
+     *  // unpin all messages
+     *  await client.unpinMessage(chat)
+     *  ```
+     */
+    unpinMessage(
+        entity: EntityLike,
+        message?: MessageIDLike,
+        unpinMessageParams?: messageMethods.UpdatePinMessageParams
+    ) {
+        return messageMethods.unpinMessage(
+            this,
+            entity,
+            message,
+            unpinMessageParams
+        );
+    }
+
     //endregion
     //region dialogs
 

--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -546,14 +546,14 @@ export interface EditMessageParams {
     /** The ID of the message (or Message itself) to be edited. If the entity was a Message, then this message will be treated as the new text. */
     message: Api.Message | number;
     /** The new text of the message. Does nothing if the entity was a Message. */
-    text: string;
+    text?: string;
     /** See the {@link TelegramClient.parseMode} property for allowed values. Markdown parsing will be used by default. */
     parseMode?: any;
     /** A list of message formatting entities. When provided, the parseMode is ignored. */
     formattingEntities?: Api.TypeMessageEntity[];
     /** Should the link preview be shown? */
     linkPreview?: boolean;
-    /** The file object that should replace the existing media in the message. */
+    /** The file object that should replace the existing media in the message. Does nothing if entity was a Message */
     file?: FileLike;
     /** Whether to send the given file as a document or not. */
     forceDocument?: false;
@@ -871,6 +871,9 @@ export async function editMessage(
         schedule,
     }: EditMessageParams
 ) {
+    if (typeof message === "number" && typeof text === "undefined" && !file) {
+        throw Error("You have to provide either file and text property.");
+    }
     entity = await client.getInputEntity(entity);
     let id: number | undefined;
     let markup: Api.TypeReplyMarkup | undefined;
@@ -903,7 +906,11 @@ export async function editMessage(
         }
         id = message;
         if (formattingEntities == undefined) {
-            [text, entities] = await _parseMessageText(client, text, parseMode);
+            [text, entities] = await _parseMessageText(
+                client,
+                text || "",
+                parseMode
+            );
         } else {
             entities = formattingEntities;
         }

--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -555,7 +555,7 @@ export interface EditMessageParams {
     linkPreview?: boolean;
     /** The file object that should replace the existing media in the message. */
     file?: FileLike;
-    /** thumbnail to be edited. */
+    /** Whether to send the given file as a document or not. */
     forceDocument?: false;
     /** The matrix (list of lists), row list or button to be shown after sending the message.<br/>
      *  This parameter will only work if you have signed in as a bot. You can also pass your own ReplyMarkup here.<br/>

--- a/gramjs/tl/custom/message.ts
+++ b/gramjs/tl/custom/message.ts
@@ -6,7 +6,11 @@ import { ChatGetter } from "./chatGetter";
 import * as utils from "../../Utils";
 import { Forward } from "./forward";
 import type { File } from "./file";
-import { EditMessageParams, SendMessageParams } from "../../client/messages";
+import {
+    EditMessageParams,
+    SendMessageParams,
+    UpdatePinMessageParams,
+} from "../../client/messages";
 import { DownloadMediaInterface } from "../../client/downloads";
 import { inspect } from "util";
 import { betterConsoleLog, returnBigInt } from "../../Helpers";
@@ -813,6 +817,30 @@ export class CustomMessage extends SenderGetter {
                     revoke,
                 }
             );
+        }
+    }
+
+    async pin(params?: UpdatePinMessageParams) {
+        if (this._client) {
+            const entity = await this.getInputChat();
+            if (entity === undefined) {
+                throw Error(
+                    "Failed to pin message due to cannot get input chat."
+                );
+            }
+            return this._client.pinMessage(entity, this.id, params);
+        }
+    }
+
+    async unpin(params?: UpdatePinMessageParams) {
+        if (this._client) {
+            const entity = await this.getInputChat();
+            if (entity === undefined) {
+                throw Error(
+                    "Failed to unpin message due to cannot get input chat."
+                );
+            }
+            return this._client.unpinMessage(entity, this.id, params);
         }
     }
 


### PR DESCRIPTION
Made some changes to editMessage function:

## Edit Message method
- Edit message method now support media.
- Update docs of `client.editMessage`. `InputBotInlineMessageID` is not supported yet so I added a warning there, I haven't tested but by looking at Telethon code it seems that I need to handle for it I will do it in the future.
- Add handler for when `message` property of `EditMessageParams` is of type `Api.Message`.
- Change `file` property type of `EditMessageParams` from `FileLike | Filelike[]` to `FileLike` because `Api.messages.EditMessage` only takes one media, not an array.
- Add return type of `Utils.getInputMedia` from return `any` to return `Api.TypeInputMedia`.
- `text` prop of `EditMessageParams` is now optional
- Add validation for if typeof `message` prop is `number` but `text` and file `props` are `undefined` then it will throws an Error

## Pin Message and Unpin Message methods
- Add client.pinMessage and client.unpinMessage methods
- Add Message.pin and Message.unpin
- Add docs for all pin and unpin methods