### PR TITLE
BREAKING CHANGES to Logger

### DIFF
--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -823,8 +823,8 @@ export class TelegramClient extends TelegramBaseClient {
      * See also {@link Message.unpin}`.
      *
      * @remarks The default behavior is to **not** notify members, unlike the official applications.
-     * @param entity - The chat where the message should be pinned.
-     * @param message - The message or the message ID to pin. If it's `undefined`, all messages will be unpinned instead.
+     * @param entity - The chat where the message should be unpinned.
+     * @param message - The message or the message ID to unpin. If it's `undefined`, all messages will be unpinned instead.
      * @param pinMessageParams - see {@link UpdatePinMessageParams}.
      * @return
      * The pinned message. if message is undefined the return will be {@link AffectedHistory}
@@ -836,7 +836,7 @@ export class TelegramClient extends TelegramBaseClient {
      *  await client.unpinMessage(chat, message);
      *
      *  // unpin all messages
-     *  await client.unpinMessage(chat)
+     *  await client.unpinMessage(chat);
      *  ```
      */
     unpinMessage(

--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -859,7 +859,7 @@ export class TelegramClient extends TelegramBaseClient {
             entity,
             message,
             unpinMessageParams
-        );
+        ) as Promise<Api.messages.AffectedHistory | undefined>;
     }
 
     /**

--- a/gramjs/client/dialogs.ts
+++ b/gramjs/client/dialogs.ts
@@ -5,6 +5,7 @@ import { Dialog } from "../tl/custom/dialog";
 import { DateLike, EntityLike } from "../define";
 import { TotalList } from "../Helpers";
 import bigInt from "big-integer";
+import { LogLevel } from "../extensions/Logger";
 
 const _MAX_CHUNK_SIZE = 100;
 
@@ -117,7 +118,7 @@ export class _DialogsIter extends RequestIter {
                     "Got error while trying to finish init message with id " +
                         m.id
                 );
-                if (this.client._log.canSend("error")) {
+                if (this.client._log.canSend(LogLevel.ERROR)) {
                     console.error(e);
                 }
             }

--- a/gramjs/client/users.ts
+++ b/gramjs/client/users.ts
@@ -11,6 +11,7 @@ import {
 import { errors, utils } from "../";
 import type { TelegramClient } from "../";
 import bigInt from "big-integer";
+import { LogLevel } from "../extensions/Logger";
 
 // UserMethods {
 // region Invoking Telegram request
@@ -330,7 +331,7 @@ export async function getInputEntity(
 
             return utils.getInputPeer(channels.chats[0]);
         } catch (e) {
-            if (client._log.canSend("error")) {
+            if (client._log.canSend(LogLevel.ERROR)) {
                 console.error(e);
             }
         }

--- a/gramjs/events/Album.ts
+++ b/gramjs/events/Album.ts
@@ -2,6 +2,7 @@ import { DefaultEventInterface, EventBuilder, EventCommon } from "./common";
 import { Entity, EntityLike } from "../define";
 import { Api } from "../tl";
 import { TelegramClient } from "..";
+import { LogLevel } from "../extensions/Logger";
 
 const _ALBUM_DELAY = 500; // 0.5 sec
 
@@ -107,7 +108,7 @@ export class AlbumEvent extends EventCommon {
                     "Got error while trying to finish init message with id " +
                         this.messages[i].id
                 );
-                if (client._log.canSend("error")) {
+                if (client._log.canSend(LogLevel.ERROR)) {
                     console.error(e);
                 }
             }

--- a/gramjs/events/NewMessage.ts
+++ b/gramjs/events/NewMessage.ts
@@ -8,6 +8,7 @@ import type { Entity, EntityLike } from "../define";
 import type { TelegramClient } from "..";
 import { Api } from "../tl";
 import bigInt from "big-integer";
+import { LogLevel } from "../extensions/Logger";
 
 export interface NewMessageInterface extends DefaultEventInterface {
     func?: { (event: NewMessageEvent): boolean };
@@ -257,7 +258,7 @@ export class NewMessageEvent extends EventCommon {
             client._log.error(
                 "Got error while trying to finish init message with id " + m.id
             );
-            if (client._log.canSend("error")) {
+            if (client._log.canSend(LogLevel.ERROR)) {
                 console.error(e);
             }
         }

--- a/gramjs/extensions/Logger.ts
+++ b/gramjs/extensions/Logger.ts
@@ -91,10 +91,6 @@ export class Logger {
         this._log(LogLevel.ERROR, message, this.colors.error);
     }
 
-    deprecationWarning(message: string) {
-        this.warn(message);
-    }
-
     format(message: string, level: string) {
         return this.messageFormat
             .replace("%t", new Date().toISOString())

--- a/gramjs/extensions/Logger.ts
+++ b/gramjs/extensions/Logger.ts
@@ -1,9 +1,17 @@
 import { IS_NODE } from "../Helpers";
 
-let _level: string | undefined = undefined;
+// let _level: string | undefined = undefined;
+
+export enum LogLevel {
+    NONE = "none",
+    ERROR = "error",
+    WARN = "warn",
+    INFO = "info",
+    DEBUG = "debug",
+}
 
 export class Logger {
-    static levels = ["error", "warn", "info", "debug"];
+    private levels = ["error", "warn", "info", "debug"];
     private readonly isBrowser: boolean;
     private colors: {
         warn: string;
@@ -14,11 +22,13 @@ export class Logger {
         info: string;
     };
     private messageFormat: string;
+    private logLevel: LogLevel;
 
-    constructor(level?: string) {
-        if (!_level) {
-            _level = level || "info"; // defaults to info
-        }
+    constructor(level?: LogLevel) {
+        // if (!_level) {
+        //     _level = level || "info"; // defaults to info
+        // }
+        this.logLevel = level || LogLevel.INFO;
         this.isBrowser = !IS_NODE;
         if (!this.isBrowser) {
             this.colors = {
@@ -47,9 +57,9 @@ export class Logger {
      * @param level {string}
      * @returns {boolean}
      */
-    canSend(level: string) {
-        return _level
-            ? Logger.levels.indexOf(_level) >= Logger.levels.indexOf(level)
+    canSend(level: LogLevel) {
+        return this.logLevel
+            ? this.levels.indexOf(this.logLevel) >= this.levels.indexOf(level)
             : false;
     }
 
@@ -57,28 +67,28 @@ export class Logger {
      * @param message {string}
      */
     warn(message: string) {
-        this._log("warn", message, this.colors.warn);
+        this._log(LogLevel.WARN, message, this.colors.warn);
     }
 
     /**
      * @param message {string}
      */
     info(message: string) {
-        this._log("info", message, this.colors.info);
+        this._log(LogLevel.INFO, message, this.colors.info);
     }
 
     /**
      * @param message {string}
      */
     debug(message: string) {
-        this._log("debug", message, this.colors.debug);
+        this._log(LogLevel.DEBUG, message, this.colors.debug);
     }
 
     /**
      * @param message {string}
      */
     error(message: string) {
-        this._log("error", message, this.colors.error);
+        this._log(LogLevel.ERROR, message, this.colors.error);
     }
 
     format(message: string, level: string) {
@@ -88,8 +98,8 @@ export class Logger {
             .replace("%m", message);
     }
 
-    static setLevel(level: string) {
-        _level = level;
+    setLevel(level: LogLevel) {
+        this.logLevel = level;
     }
 
     /**
@@ -97,22 +107,27 @@ export class Logger {
      * @param message {string}
      * @param color {string}
      */
-    _log(level: string, message: string, color: string) {
-        if (!_level) {
+    _log(level: LogLevel, message: string, color: string) {
+        if (this.canSend(level)) {
+            this.log(level, message, color);
+        } else {
             return;
         }
-        if (this.canSend(level)) {
-            if (!this.isBrowser) {
-                console.log(
-                    color + this.format(message, level) + this.colors.end
-                );
-            } else {
-                console.log(
-                    this.colors.start + this.format(message, level),
-                    color
-                );
-            }
+    }
+
+    /**
+     * Override this function for custom Logger. <br />
+     *
+     * @remarks use `this.isBrowser` to check and handle for different environment.
+     * @param level {string}
+     * @param message {string}
+     * @param color {string}
+     */
+    log(level: LogLevel, message: string, color: string) {
+        if (!this.isBrowser) {
+            console.log(color + this.format(message, level) + this.colors.end);
         } else {
+            console.log(this.colors.start + this.format(message, level), color);
         }
     }
 }

--- a/gramjs/extensions/Logger.ts
+++ b/gramjs/extensions/Logger.ts
@@ -22,13 +22,13 @@ export class Logger {
         info: string;
     };
     private messageFormat: string;
-    private logLevel: LogLevel;
+    private _logLevel: LogLevel;
 
     constructor(level?: LogLevel) {
         // if (!_level) {
         //     _level = level || "info"; // defaults to info
         // }
-        this.logLevel = level || LogLevel.INFO;
+        this._logLevel = level || LogLevel.INFO;
         this.isBrowser = !IS_NODE;
         if (!this.isBrowser) {
             this.colors = {
@@ -58,8 +58,8 @@ export class Logger {
      * @returns {boolean}
      */
     canSend(level: LogLevel) {
-        return this.logLevel
-            ? this.levels.indexOf(this.logLevel) >= this.levels.indexOf(level)
+        return this._logLevel
+            ? this.levels.indexOf(this._logLevel) >= this.levels.indexOf(level)
             : false;
     }
 
@@ -91,6 +91,10 @@ export class Logger {
         this._log(LogLevel.ERROR, message, this.colors.error);
     }
 
+    deprecationWarning(message: string) {
+        this.warn(message);
+    }
+
     format(message: string, level: string) {
         return this.messageFormat
             .replace("%t", new Date().toISOString())
@@ -98,8 +102,18 @@ export class Logger {
             .replace("%m", message);
     }
 
+    get logLevel() {
+        return this._logLevel;
+    }
+
     setLevel(level: LogLevel) {
-        this.logLevel = level;
+        this._logLevel = level;
+    }
+
+    static setLevel(level: string) {
+        console.log(
+            "Logger.setLevel is deprecated, it will has no effect. Please, use client.setLogLevel instead."
+        );
     }
 
     /**

--- a/gramjs/network/MTProtoSender.ts
+++ b/gramjs/network/MTProtoSender.ts
@@ -31,6 +31,7 @@ import {
 } from "../errors";
 import { Connection, UpdateConnectionState } from "./";
 import type { TelegramClient } from "..";
+import { LogLevel } from "../extensions/Logger";
 
 interface DEFAULT_OPTIONS {
     logger: any;
@@ -247,7 +248,7 @@ export class MTProtoSender {
                 this._log.error(
                     `WebSocket connection failed attempt: ${attempt + 1}`
                 );
-                if (this._log.canSend("error")) {
+                if (this._log.canSend(LogLevel.ERROR)) {
                     console.error(err);
                 }
                 await sleep(this._delay);

--- a/gramjs/tl/custom/message.ts
+++ b/gramjs/tl/custom/message.ts
@@ -16,6 +16,7 @@ import { inspect } from "util";
 import { betterConsoleLog, returnBigInt } from "../../Helpers";
 import { _selfId } from "../../client/users";
 import bigInt, { BigInteger } from "big-integer";
+import { LogLevel } from "../../extensions/Logger";
 
 interface MessageBaseInterface {
     id: any;
@@ -509,7 +510,7 @@ export class CustomMessage extends SenderGetter {
                 "Got error while trying to finish init message with id " +
                     this.id
             );
-            if (this._client._log.canSend("error")) {
+            if (this._client._log.canSend(LogLevel.ERROR)) {
                 console.error(e);
             }
         }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2878,6 +2878,7 @@
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.3.tgz",
       "integrity": "sha512-yEYTwGndELGvfXsImMBLop58eaGW+YdONi1fNjTINSY98tmMmFijBG6WXgdkfuLNt4imzQNtIE+eBp1PVpMCSw==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }
@@ -7785,6 +7786,7 @@
       "version": "5.0.5",
       "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-5.0.5.tgz",
       "integrity": "sha512-+pnxRYsS/axEpkrrEpzYfNZGXp0IjC/9RIxwM5gntY4Koi8SHmUGSfxfWqxZdRxrtaoVstuOzUp/rbs3JSPELQ==",
+      "hasInstallScript": true,
       "dependencies": {
         "node-gyp-build": "^4.2.0"
       }


### PR DESCRIPTION
#### **Refactor: improve Logger**
- **BREAKING CHANGE: Replace `Logger.setLevel` with `client.setLogLevel`**
- **BREAKING CHANGE: Anywhere you used string to set log level will now need to replace using `LogLevel` enum. E.g: `client.setLogLevel(LogLevel.ERROR)`**
- User can now pass in a custom logger as `baseLogger` as long as the custom logger extends `Logger`
- Create enum `LogLevel` to reduce potential typo errors
- Add `client.logger` return the baseLogger
- Add deprecated warning to `Logger.setLevel`
- Add getter to `Logger` for getting the current log level