### PR TITLE
Deleted message event

### DIFF
--- a/gramjs/Utils.ts
+++ b/gramjs/Utils.ts
@@ -1174,7 +1174,7 @@ export function  _getEntityPair(entityId, entities, cache, getInputPeer = getInp
 export function getMessageId(
     message: number | Api.TypeMessage | MessageIDLike | undefined
 ): number | undefined {
-    if (message === null || message === undefined) {
+    if (!message) {
         return undefined;
     } else if (typeof message === "number") {
         return message;

--- a/gramjs/Utils.ts
+++ b/gramjs/Utils.ts
@@ -1172,7 +1172,7 @@ export function  _getEntityPair(entityId, entities, cache, getInputPeer = getInp
 */
 
 export function getMessageId(
-    message: number | Api.TypeMessage | MessageIDLike
+    message: number | Api.TypeMessage | MessageIDLike | undefined
 ): number | undefined {
     if (message === null || message === undefined) {
         return undefined;

--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -28,6 +28,7 @@ import { inspect } from "util";
 import { Album, AlbumEvent } from "../events/Album";
 import { CallbackQuery, CallbackQueryEvent } from "../events/CallbackQuery";
 import { EditedMessage, EditedMessageEvent } from "../events/EditedMessage";
+import { DeletedMessage, DeletedMessageEvent } from "../events/DeletedMessage";
 
 /**
  * The TelegramClient uses several methods in different files to provide all the common functionality in a nice interface.</br>
@@ -1045,6 +1046,10 @@ export class TelegramClient extends TelegramBaseClient {
     addEventHandler(
         callback: { (event: EditedMessageEvent): void },
         event: EditedMessage
+    ): void;
+    addEventHandler(
+        callback: { (event: DeletedMessageEvent): void },
+        event: DeletedMessage
     ): void;
     addEventHandler(
         callback: { (event: any): void },

--- a/gramjs/events/DeletedMessage.ts
+++ b/gramjs/events/DeletedMessage.ts
@@ -1,0 +1,71 @@
+import { EntityLike } from "../define";
+import { Api } from "../tl";
+import { EventBuilder, EventCommon, DefaultEventInterface } from "./common";
+
+/**
+ * Occurs whenever a message is deleted. Note that this event isn't 100%
+ * reliable, since Telegram doesn't always notify the clients that a message
+ * was deleted.
+ *
+ * @remarks
+ * Telegram **does not** send information about *where* a message
+ * was deleted if it occurs in private conversations with other users
+ * or in small group chats, because message IDs are *unique* and you
+ * can identify the chat with the message ID alone if you saved it
+ * previously.
+ *
+ * Telethon **does not** save information of where messages occur,
+ * so it cannot know in which chat a message was deleted (this will
+ * only work in channels, where the channel ID *is* present).
+ *
+ * This means that the `chats=` parameter will not work reliably,
+ * unless you intend on working with channels and super-groups only.
+ *
+ * @example
+ * ```ts
+ * async function deletedMessageEventPrint(event: DeletedMessageEvent) {
+ *
+ *   for (let index = 0; index < update.deletedIds.length; index++) {
+ *     const deletedMsgId = update.deletedIds[index];
+ *     console.log(`Message ${deletedMsgId} was deleted.`)
+ *   }
+ *
+ * }
+ * // adds an event handler for deleted messages
+ * client.addEventHandler(deletedMessageEventPrint, new DeletedMessage({}));
+ * ```
+ */
+export class DeletedMessage extends EventBuilder {
+    constructor(eventParams: DefaultEventInterface) {
+        super(eventParams);
+    }
+
+    build(
+        update: Api.TypeUpdate | Api.TypeUpdates,
+        callback: undefined,
+        selfId: bigInt.BigInteger
+    ) {
+        if (update instanceof Api.UpdateDeleteChannelMessages) {
+            return new DeletedMessageEvent(
+                update.messages,
+                new Api.PeerChannel({ channelId: update.channelId })
+            );
+        } else if (update instanceof Api.UpdateDeleteMessages) {
+            return new DeletedMessageEvent(update.messages);
+        }
+    }
+}
+
+export class DeletedMessageEvent extends EventCommon {
+    deletedIds: number[];
+    peer?: EntityLike;
+
+    constructor(deletedIds: number[], peer?: EntityLike) {
+        super({
+            chatPeer: peer,
+            msgId: (deletedIds || [0])[0],
+        });
+        this.deletedIds = deletedIds;
+        this.peer = peer;
+    }
+}

--- a/gramjs/events/DeletedMessage.ts
+++ b/gramjs/events/DeletedMessage.ts
@@ -14,11 +14,11 @@ import { EventBuilder, EventCommon, DefaultEventInterface } from "./common";
  * can identify the chat with the message ID alone if you saved it
  * previously.
  *
- * Telethon **does not** save information of where messages occur,
+ * GramJS **does not** save information of where messages occur,
  * so it cannot know in which chat a message was deleted (this will
  * only work in channels, where the channel ID *is* present).
  *
- * This means that the `chats=` parameter will not work reliably,
+ * This means that the `chats:` parameter will not work reliably,
  * unless you intend on working with channels and super-groups only.
  *
  * @example
@@ -63,7 +63,7 @@ export class DeletedMessageEvent extends EventCommon {
     constructor(deletedIds: number[], peer?: EntityLike) {
         super({
             chatPeer: peer,
-            msgId: (deletedIds || [0])[0],
+            msgId: Array.isArray(deletedIds) ? deletedIds[0] : 0,
         });
         this.deletedIds = deletedIds;
         this.peer = peer;

--- a/gramjs/events/EditedMessage.ts
+++ b/gramjs/events/EditedMessage.ts
@@ -14,7 +14,7 @@ export interface EditedMessageInterface extends NewMessageInterface {
  *
  *   console.log(`Message ${message.id} from channel ${message.chatId!.toString();} was edited at ${message.editDate}`)
  * }
- * // adds an event handler for new messages
+ * // adds an event handler for edited messages
  * client.addEventHandler(editedEventPrint, new EditedMessage({}));
  * ```
  */


### PR DESCRIPTION
#### Bug fixes 
- Add undefined type to `message` param of `getMessageId`
- Fix a typo in `EditedMessage` event docs

#### Features:
- Deleted message event