### PR TITLE
added getPasswordSrpCheck function that uses computePasswordSrpCheck

### DIFF
--- a/gramjs/client/auth.ts
+++ b/gramjs/client/auth.ts
@@ -388,6 +388,15 @@ export async function sendCode(
     }
 }
 
+export async function getPasswordSrpCheck(passwordSrpResult:any,password : string){
+    const passwordSrpCheck = await computePasswordSrpCheck(
+        passwordSrpResult,
+        password
+    );
+
+    return passwordSrpCheck
+}
+
 /** @hidden */
 export async function signInWithPassword(
     client: TelegramClient,
@@ -410,7 +419,7 @@ export async function signInWithPassword(
                 throw new Error("Password is empty");
             }
 
-            const passwordSrpCheck = await computePasswordSrpCheck(
+            const passwordSrpCheck = await getPasswordSrpCheck(
                 passwordSrpResult,
                 password
             );


### PR DESCRIPTION
added a getPasswordSrpCheck function  to be used in the independately, to check passwordSRP

USE:
for browser's user experience (some have 2FA enabled and some don't).

LOGIC:
the best login flow for the browser is to let the user put the his phone
then get the code
once he puts in the his code, we can then check if he has 2FA enabled
if he do have it enabled, we need to check the passwordSRP, and that's where the getPasswordSrpCheck comes in.

PROBLEM:
computeCheck exists in Password.ts file, I didn't want to change it to public so instead I added a function that uses and exposed it in the client instance still