### PR TITLE
POC to use AbortSignal to cancel an ongoing download

### DIFF
--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -492,7 +492,8 @@ export class TelegramClient extends TelegramBaseClient {
             messageOrMedia,
             downloadParams.outputFile,
             downloadParams.thumb,
-            downloadParams.progressCallback
+            downloadParams.progressCallback,
+            downloadParams.abortSignal
         );
     }
 


### PR DESCRIPTION
Currently gramjs doesn't provide any way to cancel/abort an ongoing download.
I implemented a simple system which uses AbortController and AbortSignal to break the loop which fetches the chunks.

This is a POC so that we can discuss if there are any caveats in this idea. This can be simillary implemented for all other kinds of downloads (document, video, profile picture, etc).

Example:
```typescript
const abortController = new AbortController()
const buffer = await msg.downloadMedia({
  abortSignal: abortController.signal
})

// In some place else we can call
abortController.abort()
```

This raises an `USER_ABORTED` error from downloadMedia which can be handled by the client.

Note: This implementation is only checked with Nodejs, I haven't tested it in browsers.