### PR TITLE
Remove redundant clientside filtering from iterMessages method

### DIFF
--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -45,7 +45,6 @@ export class _MessagesIter extends RequestIter {
         | Api.messages.GetReplies
         | Api.messages.GetHistory
         | Api.messages.Search;
-    fromId?: string | bigInt.BigInteger;
     addOffset?: number;
     maxId?: number;
     minId?: number;
@@ -98,9 +97,6 @@ export class _MessagesIter extends RequestIter {
         }
         if (fromUser) {
             fromUser = await this.client.getInputEntity(fromUser);
-            this.fromId = await this.client.getPeerId(fromUser);
-        } else {
-            this.fromId = undefined;
         }
 
         if (!this.entity && fromUser) {
@@ -139,11 +135,7 @@ export class _MessagesIter extends RequestIter {
             fromUser !== undefined
         ) {
             const ty = _entityType(this.entity);
-            if (ty == _EntityType.USER) {
-                fromUser = undefined;
-            } else {
-                this.fromId = undefined;
-            }
+
             this.request = new Api.messages.Search({
                 peer: this.entity,
                 q: search || "",
@@ -240,9 +232,6 @@ export class _MessagesIter extends RequestIter {
             ? (r.messages.reverse() as unknown as Api.Message[])
             : (r.messages as unknown as Api.Message[]);
         for (const message of messages) {
-            if (this.fromId && message.senderId?.notEquals(this.fromId)) {
-                continue;
-            }
             if (!this._messageInRange(message)) {
                 return true;
             }


### PR DESCRIPTION
Hi all!
## PR Motivation
TL;DR;
I suggest to remove client side filtering by formId from iterMesssages, because it works on server side now

Two more benefits:
1. Solves issue when chunk contains 0 messages matching fromId, but 100 from another user (example down below)
2. Doesnt remove formId from Api.messages.Search query, which makes loading faster

----------
## Initial problem:
I've run into an issue with client.iterMessages

When trying to get messages with search by me in chat with user, I get an exception
```js
client.iterMessages(dialog.entity, {
      search: keyword,
      fromUser: 'me'
    });
```

```
node_modules/.pnpm/telegram@2.6.13/node_modules/telegram/client/messages.j3
    this.request.offsetId = Number(lastMessage.id);
                                               ^

TypeError: Cannot read properties of undefined (reading 'id')
    at _MessagesIter._updateOffset (/home/viktor/dev/tgMessageCleaner/node_modules/.pnpm/telegram@2.6.13/nod)
    at _MessagesIter._loadNextChunk (/home/viktor/dev/tgMessageCleaner/node_modules/.pnpm/telegram@2.6.13/no)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async Object.next (/home/viktor/dev/tgMessageCleaner/node_modules/.pnpm/telegram@2.6.13/node_modules/)
    at async findMessagesByKeyword (file:///home/viktor/dev/tgMessageCleaner/index.mjs:83:22)
    at async file:///home/viktor/dev/tgMessageCleaner/index.mjs:23:18
 ELIFECYCLE  Command failed with exit code 1.
```

I debugged, that's happing because there are more than 100 messages from another user matching search, but 0 from me and library-side filtering fails

I guess that library-side filtering is present, because telegram used to ignore fromId parameter in Search when entity is User chat. But now server side filtering by fromId works well in User chats too

To check server side filtering, I've tried:
```js
const result = await client.invoke(new Api.messages.Search({
  peer: "partnerusername",
  q: 'some word you partner likes but you do not use ever',
  filter: new Api.InputMessagesFilterEmpty(),
  limit: 50,
  fromId: "your user name"
}));
```
returns 0 messages for me with formId parameter specified and some messages without it (its messages from another user)

So server side filtering works fine now