### PR TITLE
Fix resending batched messages

### DIFF
--- a/gramjs/network/MTProtoSender.ts
+++ b/gramjs/network/MTProtoSender.ts
@@ -593,7 +593,7 @@ export class MTProtoSender {
 
         const toPop = [];
 
-        for (const state of Object.values(this._pendingState)) {
+        for (const state of this._pendingState.values()) {
             if (state.containerId && state.containerId.equals(msgId)) {
                 toPop.push(state.msgId);
             }
@@ -602,8 +602,8 @@ export class MTProtoSender {
         if (toPop.length) {
             const temp = [];
             for (const x of toPop) {
-                temp.push(this._pendingState.get(x));
-                this._pendingState.delete(x);
+                temp.push(this._pendingState.get(x!.toString()));
+                this._pendingState.delete(x!.toString());
             }
             return temp;
         }

--- a/gramjs/network/RequestState.ts
+++ b/gramjs/network/RequestState.ts
@@ -1,7 +1,7 @@
 import bigInt from "big-integer";
 
 export class RequestState {
-    public containerId: undefined;
+    public containerId?: bigInt.BigInteger;
     public msgId?: bigInt.BigInteger;
     public request: any;
     public data: Buffer;

--- a/gramjs/sessions/StoreSession.ts
+++ b/gramjs/sessions/StoreSession.ts
@@ -1,11 +1,11 @@
 import { MemorySession } from "./Memory";
-import store from "store2";
+import store, {StoreBase} from "store2";
 import { AuthKey } from "../crypto/AuthKey";
 import bigInt from "big-integer";
 
 export class StoreSession extends MemorySession {
     private readonly sessionName: string;
-    private store: store.StoreAPI;
+    private store: StoreBase;
 
     constructor(sessionName: string, divider = ":") {
         super();


### PR DESCRIPTION
Due to a bug with iterating `Map` values, batched messages are never re-sent. This PR fixes it and also corrects a couple of errors related to type checking.

I believe this also closes #178. I reproduced the bug when signing in with a phone number that is served by another DC. When reconnecting, a client tries to send `help.GetConfig` and `MsgsAck` messages in a batch, receives a bad salt message, but never resends them because resending batches is broken (this is why the client also got stuck).