### PR TITLE
Fix reconnecting the client

### DIFF
--- a/gramjs/network/MTProtoSender.ts
+++ b/gramjs/network/MTProtoSender.ts
@@ -270,6 +270,7 @@ export class MTProtoSender {
                 await sleep(this._delay);
             }
         }
+        this.userDisconnected = false;
         this.isConnecting = false;
         return true;
     }
@@ -480,7 +481,6 @@ export class MTProtoSender {
         let message;
 
         while (this._userConnected && !this._reconnecting) {
-            // this._log.debug('Receiving items from the network...');
             this._log.debug("Receiving items from the network...");
             try {
                 body = await this._connection!.recv();


### PR DESCRIPTION
This PR actually fixes #334 (even though it was closed by the author) so that users won't need to employ the hacks by manually reconnecting the client.

Currently, the library handles reconnecting just fine, but only once. As we forget to set `userDisconnected` to `false` after connecting, the next fail in the `_recvLoop` function won't trigger reconnecting again:
https://github.com/gram-js/gramjs/blob/4a641ffba2dee5d059f1624f5285fc335eff358c/gramjs/network/MTProtoSender.ts#L489-L492