### PR TITLE
Add support of 4GB files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ example.d.ts
 settings
 
 /browser/
+
+.DS_STORE

--- a/gramjs/client/fs-BROWSER.ts
+++ b/gramjs/client/fs-BROWSER.ts
@@ -2,6 +2,7 @@ export const promises = {
     lstat: (...args: any): any => {},
     stat: (...args: any): any => {},
     readFile: (...args: any): any => {},
+    open: (...args: any): any => {},
 };
 export const createWriteStream: any = {};
 export const WriteStream: any = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "telegram",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "telegram",
-      "version": "2.9.0",
+      "version": "2.9.2",
       "license": "MIT",
       "dependencies": {
         "@cryptography/aes": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "telegram",
-  "version": "2.9.0",
+  "version": "2.9.2",
   "description": "NodeJS/Browser MTProto API Telegram client library,",
   "main": "index.js",
   "types": "index.d.ts",

--- a/prepare_dist.sh
+++ b/prepare_dist.sh
@@ -1,0 +1,10 @@
+tsc
+cp package.json dist/
+cp README.md dist/
+cp LICENSE dist/
+
+mkdir -p dist/tl/static
+cp gramjs/tl/static/api.tl dist/tl/static/
+cp gramjs/tl/static/schema.tl dist/tl/static/
+cp gramjs/tl/api.d.ts dist/tl/
+cp gramjs/define.d.ts dist/


### PR DESCRIPTION
Telegram Premium introduces increased upload size to 4GB. But unfortunately most operating systems don't allow to open files (to consume it entirely into a memory) bigger that to 2GB (see https://github.com/nodejs/node/blob/15bb82b268584ad206606ffd46cc78c929c93fca/lib/internal/fs/utils.js#L130 ), so if we try to upload a big file (>2GB) via client we will get an error.

This is a quick fix I made to by pass this issue (already tested with uploading a big video files and it works great), but I'm not sure how good it's enough, how will it work in browsers, etc., so please review.

Also I made a helper script so I can build my fork and use it in my app (it was not easy to figure out things 😓 ) instead of package from NPM, but I can delete it if it's unnecessary.

P.S. Actually, not sure is it possible to use streams, instead of operating with buffers.