### PR TITLE
Fix `flags.n?Bool` is incorrectly ignored

### DIFF
--- a/gramjs/tl/api.js
+++ b/gramjs/tl/api.js
@@ -424,7 +424,7 @@ function createClasses(classesType, params) {
                     if (argsConfig.hasOwnProperty(arg)) {
                         if (argsConfig[arg].isFlag) {
                             if (
-                                this[arg] === false ||
+                                (this[arg] === false && argsConfig[arg].type !== 'Bool') ||
                                 this[arg] === null ||
                                 this[arg] === undefined ||
                                 argsConfig[arg].type === "true"
@@ -460,7 +460,7 @@ function createClasses(classesType, params) {
                                 for (const f in argsConfig) {
                                     if (argsConfig[f].isFlag) {
                                         if (
-                                            this[f] === false ||
+                                            (this[f] === false && argsConfig[f].type !== 'Bool') ||
                                             this[f] === undefined ||
                                             this[f] === null
                                         ) {


### PR DESCRIPTION
Bug description:
```js
import { Api } from 'telegram'

// globalPrivacySettings#bea2f424 flags:# archive_and_mute_new_noncontact_peers:flags.0?Bool = GlobalPrivacySettings;

let t1 = new Api.GlobalPrivacySettings({
  archiveAndMuteNewNoncontactPeers: false
})
console.log(t1.getBytes())
// expect: <Buffer 24 f4 a2 be 01 00 00 00 37 97 79 bc>
// actual: <Buffer 24 f4 a2 be 00 00 00 00> ❌

let t2 = new Api.GlobalPrivacySettings({
  flags: 1,
  archiveAndMuteNewNoncontactPeers: false
})
console.log(t2.getBytes())
// expect: <Buffer 24 f4 a2 be 01 00 00 00 37 97 79 bc>
// actual: <Buffer 24 f4 a2 be 00 00 00 00> ❌

let t3 = new Api.GlobalPrivacySettings({

})
console.log(t3.getBytes())
// expect: <Buffer 24 f4 a2 be 00 00 00 00>
// actual: <Buffer 24 f4 a2 be 00 00 00 00> ✔
```