### PR TITLE
Support situations that low memory server (512MB) to send a big file (over 500MB)

### DIFF
--- a/gramjs/client/uploads.ts
+++ b/gramjs/client/uploads.ts
@@ -98,12 +98,10 @@ const DISCONNECT_SLEEP = 1000;
 async function getFileBuffer(
     file: File | CustomFile,
     fileSize: number,
-    maxBufferSize?: number
+    maxBufferSize: number
 ): Promise<CustomBuffer> {
-    const isBiggerThan2Gb = fileSize > 2 ** 31 - 1;
-    const usePath = maxBufferSize ? fileSize > maxBufferSize : false;
     const options: CustomBufferOptions = {};
-    if ((usePath || isBiggerThan2Gb) && file instanceof CustomFile) {
+    if (fileSize > maxBufferSize && file instanceof CustomFile) {
         options.filePath = file.path;
     } else {
         options.buffer = Buffer.from(await fileToBuffer(file));
@@ -126,7 +124,7 @@ export async function uploadFile(
 
     const partSize = getAppropriatedPartSize(bigInt(size)) * KB_TO_BYTES;
     const partCount = Math.floor((size + partSize - 1) / partSize);
-    const buffer = await getFileBuffer(file, size, fileParams.maxBufferSize);
+    const buffer = await getFileBuffer(file, size, fileParams.maxBufferSize || /* 2G */ 2 ** 31 - 1);
 
     // Make sure a new sender can be created before starting upload
     await client.getSender(client.session.dcId);

--- a/gramjs/client/uploads.ts
+++ b/gramjs/client/uploads.ts
@@ -94,6 +94,7 @@ const KB_TO_BYTES = 1024;
 const LARGE_FILE_THRESHOLD = 10 * 1024 * 1024;
 const UPLOAD_TIMEOUT = 15 * 1000;
 const DISCONNECT_SLEEP = 1000;
+const BUFFER_SIZE_2GB = 2 ** 31;
 
 async function getFileBuffer(
     file: File | CustomFile,
@@ -124,7 +125,7 @@ export async function uploadFile(
 
     const partSize = getAppropriatedPartSize(bigInt(size)) * KB_TO_BYTES;
     const partCount = Math.floor((size + partSize - 1) / partSize);
-    const buffer = await getFileBuffer(file, size, fileParams.maxBufferSize || /* 2G */ 2 ** 31 - 1);
+    const buffer = await getFileBuffer(file, size, fileParams.maxBufferSize || BUFFER_SIZE_2GB  - 1);
 
     // Make sure a new sender can be created before starting upload
     await client.getSender(client.session.dcId);


### PR DESCRIPTION
Add optional maxBufferSize parameter in updateFile function for support upload big file with low memory overhead.

It will use maximal 2G memory for sending a big file in the current implementation, this requires a big cost for the server host fee.