### PR TITLE
Fix issues with `readBufferFromBigInt` when `little=true`, `signed=true`

### DIFF
--- a/gramjs/Helpers.ts
+++ b/gramjs/Helpers.ts
@@ -143,37 +143,20 @@ export function readBufferFromBigInt(
     }
 
     const hex = bigIntVar.toString(16).padStart(bytesNumber * 2, "0");
-    let littleBuffer = Buffer.from(hex, "hex");
-    if (little) {
-        littleBuffer = littleBuffer.reverse();
-    }
+    let buffer = Buffer.from(hex, "hex");
 
     if (signed && below) {
-        if (little) {
-            let reminder = false;
-            if (littleBuffer[0] !== 0) {
-                littleBuffer[0] -= 1;
+            buffer[buffer.length - 1] =
+                256 - buffer[buffer.length - 1];
+            for (let i = 0; i < buffer.length - 1; i++) {
+                buffer[i] = 255 - buffer[i];
             }
-            for (let i = 0; i < littleBuffer.length; i++) {
-                if (littleBuffer[i] === 0) {
-                    reminder = true;
-                    continue;
-                }
-                if (reminder) {
-                    littleBuffer[i] -= 1;
-                    reminder = false;
-                }
-                littleBuffer[i] = 255 - littleBuffer[i];
-            }
-        } else {
-            littleBuffer[littleBuffer.length - 1] =
-                256 - littleBuffer[littleBuffer.length - 1];
-            for (let i = 0; i < littleBuffer.length - 1; i++) {
-                littleBuffer[i] = 255 - littleBuffer[i];
-            }
-        }
+
+    } if (little) {
+        buffer = buffer.reverse();
     }
-    return littleBuffer;
+
+    return buffer;
 }
 
 /**


### PR DESCRIPTION
Currently, the function misbehaves if we try to read a signed big int as LE. For example, if you try reading `-0x010001` as unsigned LE, `<Buffer 00 00 ff 00>` will be returned while in fact, it should return `b'\xff\xff\xfe\xff'`. This PR fixes that.