### PR TITLE
Fix order on progressCallback params

### DIFF
--- a/gramjs/define.d.ts
+++ b/gramjs/define.d.ts
@@ -64,8 +64,8 @@ type OutFile =
     | WriteStream
     | { write: Function; close?: Function };
 type ProgressCallback = (
-    total: bigInt.BigInteger,
-    downloaded: bigInt.BigInteger
+    downloaded: bigInt.BigInteger,
+    total: bigInt.BigInteger
 ) => void;
 type ButtonLike = Api.TypeKeyboardButton | Button;
 


### PR DESCRIPTION
Currently the order of the progressCallback params while downloading media is as follows: `total`, `downloaded`

![image](https://github.com/gram-js/gramjs/assets/121819737/4f501eef-d3b6-46b0-b790-0c5adee79ea8)

But when we run code like this to check what's in `total` and `downloaded`:

```ts
await message.downloadMedia({
  progressCallback(total, downloaded) {
    console.log({ total, downloaded });
  },
});
```
We will get the following result:

![image](https://github.com/gram-js/gramjs/assets/121819737/90379f0e-a069-42ed-b8ac-95edabb5ba6d)