### PR TITLE
fix(connection): close underlying socket

### DIFF
--- a/gramjs/Helpers.ts
+++ b/gramjs/Helpers.ts
@@ -426,10 +426,13 @@ export function getRandomInt(min: number, max: number): number {
 /**
  * Sleeps a specified amount of time
  * @param ms time in milliseconds
+ * @param isUnref make a timer unref'ed
  * @returns {Promise}
  */
-export const sleep = (ms: number) =>
-    new Promise((resolve) => setTimeout(resolve, ms));
+export const sleep = (ms: number, isUnref: boolean = false) =>
+    new Promise((resolve) =>
+        isUnref ? setTimeout(resolve, ms).unref() : setTimeout(resolve, ms)
+    );
 
 /**
  * Helper to export two buffers of same length

--- a/gramjs/client/updates.ts
+++ b/gramjs/client/updates.ts
@@ -187,7 +187,8 @@ export async function _dispatchUpdate(
 export async function _updateLoop(client: TelegramClient) {
     let lastPongAt;
     while (!client._destroyed) {
-        await sleep(PING_INTERVAL);
+        await sleep(PING_INTERVAL, true);
+        if (client._destroyed) break;
         if (client._sender!.isReconnecting || client._isSwitchingDc) {
             lastPongAt = undefined;
             continue;

--- a/gramjs/network/connection/Connection.ts
+++ b/gramjs/network/connection/Connection.ts
@@ -103,6 +103,7 @@ class Connection {
 
         this._connected = false;
         void this._recvArray.push(undefined);
+        await this.socket.close();
     }
 
     async send(data: Buffer) {


### PR DESCRIPTION
Simple app keep process running after calling `disconnect()`

```js
const { TelegramClient } = require("telegram");
const { StringSession } = require("telegram/sessions");

(async () => {
  const apiId = "<api_id>";
  const apiHash = "<api_hash>";
  const sess = new StringSession("");
  const client = new TelegramClient(sess, apiId, apiHash, {});
  await client.connect();
  await client.disconnect();
})();

```