### PR TITLE
fix #585: Dialog's top message can be undefined

### DIFF
--- a/gramjs/tl/custom/dialog.ts
+++ b/gramjs/tl/custom/dialog.ts
@@ -14,7 +14,7 @@ export class Dialog {
     folderId?: number;
     archived: boolean;
     message?: Api.Message;
-    date: number;
+    date?: number;
     entity?: Entity;
     inputEntity: Api.TypeInputPeer;
     id?: bigInt.BigInteger;
@@ -42,7 +42,7 @@ export class Dialog {
         this.folderId = dialog.folderId;
         this.archived = dialog.folderId != undefined;
         this.message = message;
-        this.date = this.message!.date!;
+        this.date = this.messager?.date;
 
         this.entity = entities.get(getPeerId(dialog.peer));
         this.inputEntity = getInputPeer(this.entity);


### PR DESCRIPTION
Fixes #585 by making Dialog's `date` property optional. This prop is the dialog's "top message" date and since that can be undefined, the date can be undefined, too.

With this change, I can use getDialogs and do not experience any unwanted side effects.