### PR TITLE
fix ProgressCallback

### DIFF
--- a/gramjs/client/downloads.ts
+++ b/gramjs/client/downloads.ts
@@ -430,13 +430,13 @@ export async function downloadFileV2(
             msgData: msgData,
         })) {
             await writer.write(chunk);
+            downloaded = downloaded.add(chunk.length);
             if (progressCallback) {
                 await progressCallback(
                     downloaded,
                     bigInt(fileSize || bigInt.zero)
                 );
             }
-            downloaded = downloaded.add(chunk.length);
         }
         return returnWriterValue(writer);
     } finally {

--- a/gramjs/define.d.ts
+++ b/gramjs/define.d.ts
@@ -64,8 +64,8 @@ type OutFile =
     | WriteStream
     | { write: Function; close?: Function };
 type ProgressCallback = (
-    total: bigInt.BigInteger,
-    downloaded: bigInt.BigInteger
+    downloaded: bigInt.BigInteger,
+    total: bigInt.BigInteger
 ) => void;
 type ButtonLike = Api.TypeKeyboardButton | Button;
 


### PR DESCRIPTION
### Wrong params order of `ProgressCallback`
- The correct order should be `downloaded, total`, not `total, downloaded`.

### Wrong calling time of `progressCallback` when downloading
- The actual number of downloaded bytes should be updated first before the results are reflected in the `progressCallback`, or else the progress will never reach 100%.