### PR TITLE
docs: fix and lint @example of getEntity

### DIFF
--- a/gramjs/client/TelegramClient.ts
+++ b/gramjs/client/TelegramClient.ts
@@ -1277,11 +1277,11 @@ export class TelegramClient extends TelegramBaseClient {
      * @example
      * ```ts
      * const me = await client.getEntity("me");
-     * console.log("My name is",utils.getDisplayName(me));
+     * console.log("My name is", utils.getDisplayName(me));
      *
      * const chat = await client.getInputEntity("username");
-     * for await (const message of client.iterMessages(chat){
-     *     console.log("Message text is",message.text);
+     * for await (const message of client.iterMessages(chat)) {
+     *     console.log("Message text is", message.text);
      * }
      *
      * // Note that you could have used the username directly, but it's


### PR DESCRIPTION
The examples misses a closing bracket, this PR fixes it plus some whitespace