### PR TITLE
Fix bug in getCommentData that made the flag commentTo respond to the wrong message

### DIFF
--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -1175,7 +1175,8 @@ export async function getCommentData(
             msgId: utils.getMessageId(message),
         })
     );
-    const relevantMessage = result.messages[0];
+    const relevantMessage = result.messages
+                            .reduce((p: Api.TypeMessage, c: Api.TypeMessage) => (p && p.id < c.id ? p : c));
     let chat;
     for (const c of result.chats) {
         if (


### PR DESCRIPTION
This bug occurred only if there was more than 1 media file in the message. This was happening because it was responding to the last media file uploaded.

Example of the bug:
![image](https://github.com/user-attachments/assets/776e5001-223e-43ee-80dc-ef62134e0eaf)
![image](https://github.com/user-attachments/assets/2f436ca5-b6d6-43b8-b4f8-a422de656d2c)
After posting a message with 2 images, I expect that the comment will not link to any message, but it refer to the last uploaded media.

On the other hand, if there are only 1 or 0 media, the bug does not occur:
![image](https://github.com/user-attachments/assets/7ad2c456-54c6-4506-913d-08c7228e84d4)
![image](https://github.com/user-attachments/assets/70fd1331-295b-4c31-8d45-471fa7a05bd2)

![image](https://github.com/user-attachments/assets/199af291-4646-4115-889e-8347cc676a7d)
![image](https://github.com/user-attachments/assets/576589e5-a4ef-451d-ad5a-701cce31371d)


Using the [Telethon](https://github.com/LonamiWebs/Telethon) python client this behavior did not occur. After checking the source code I found that [Telethon takes the message from the discussion with the lowest id](https://github.com/LonamiWebs/Telethon/blob/a5c98aec50891e973b1ae4f38b8c080444aae664/telethon/client/messages.py#L622), instead [this library takes the first message from the array](https://github.com/gram-js/gramjs/blob/9233537e172ffce6d44a09454b7c75369a846bbf/gramjs/client/messages.ts#L1178), which corresponds to the last uploaded media.