### PR TITLE
chore: Update max buffer size for file uploads to 20MB

### DIFF
--- a/gramjs/client/uploads.ts
+++ b/gramjs/client/uploads.ts
@@ -95,6 +95,7 @@ const LARGE_FILE_THRESHOLD = 10 * 1024 * 1024;
 const UPLOAD_TIMEOUT = 15 * 1000;
 const DISCONNECT_SLEEP = 1000;
 const BUFFER_SIZE_2GB = 2 ** 31;
+const BUFFER_SIZE_20MB = 20 * 1024 * 1024;
 
 async function getFileBuffer(
     file: File | CustomFile,
@@ -128,7 +129,7 @@ export async function uploadFile(
     const buffer = await getFileBuffer(
         file,
         size,
-        fileParams.maxBufferSize || BUFFER_SIZE_2GB - 1
+        fileParams.maxBufferSize || BUFFER_SIZE_20MB - 1
     );
 
     // Make sure a new sender can be created before starting upload


### PR DESCRIPTION
Temporary fix for upload memory usage.