### PR TITLE
Forbid 'session' as sessionName in StoreSession.ts (Close #480)

### DIFF
--- a/gramjs/sessions/StoreSession.ts
+++ b/gramjs/sessions/StoreSession.ts
@@ -9,6 +9,9 @@ export class StoreSession extends MemorySession {
 
     constructor(sessionName: string, divider = ":") {
         super();
+        if (sessionName === "session") {
+            throw new Error("Session name can't be 'session'. Please use a different name.");
+        }
         if (typeof localStorage === "undefined" || localStorage === null) {
             const LocalStorage = require("./localStorage").LocalStorage;
             this.store = store.area(


### PR DESCRIPTION
Related issue #480 

My guess the reason of the issue is that `session` key is being used by store2 internally and it leads to unintended overrides: https://github.com/nbubna/store/blob/0216588bc53505e290c537aaae2c52fa5ad47df8/src/store2.js#L272

The issue we're trying to solve is that when a user of gramjs is using the library for the first time, it's tempting to name the session folder `session`. However, doing so doesn't lead to persisting anything. The user may think the issue is related to his code or folder permissions. It's not obvious that the session name is the reason of the issue.

To solve this, I suggest forbidding the use `session` as a name and throwing an exception instead. Another option could be to prefix the session name with something like `gramjs_${sessionName}`, but I'm afraid it might cause a backward compatibility break.

