### PR TITLE
User Account bold markdown fix

### DIFF
--- a/gramjs/extensions/markdown.ts
+++ b/gramjs/extensions/markdown.ts
@@ -38,7 +38,7 @@ export class MarkdownParser {
                     foundIndex - tempEntities[foundDelim].offset;
                 entities.push(tempEntities[foundDelim]);
             }
-            message = message.replace(foundDelim, "");
+            message = message.toString().replace(foundDelim, "");
             i = foundIndex;
         }
         return [message, entities];


### PR DESCRIPTION
When you send a message with a user account with "**" to render dark text, you get the error:
```js
TypeError: message.replace is not a function
```
convert "message" buffer to string to avoid this