### PR TITLE
chore: stricter ProxyInterface

### DIFF
--- a/gramjs/client/telegramBaseClient.ts
+++ b/gramjs/client/telegramBaseClient.ts
@@ -284,11 +284,11 @@ export abstract class TelegramBaseClient {
         }
         this._connection = clientParams.connection;
         let initProxy;
-        if (this._proxy?.MTProxy) {
+        if (this._proxy && 'MTProxy' in this._proxy) {
             this._connection = ConnectionTCPMTProxyAbridged;
             initProxy = new Api.InputClientProxy({
-                address: this._proxy!.ip,
-                port: this._proxy!.port,
+                address: this._proxy.ip,
+                port: this._proxy.port,
             });
         }
         this._initRequest = new Api.InitConnection({

--- a/gramjs/extensions/PromisedNetSockets.ts
+++ b/gramjs/extensions/PromisedNetSockets.ts
@@ -2,7 +2,7 @@ import * as net from "./net";
 import { SocksClient } from "./socks";
 
 import { Mutex } from "async-mutex";
-import { ProxyInterface } from "../network/connection/TCPMTProxy";
+import { ProxyInterface, SocksProxyType } from "../network/connection/TCPMTProxy";
 
 const mutex = new Mutex();
 
@@ -14,22 +14,22 @@ export class PromisedNetSockets {
     private stream: Buffer;
     private canRead?: boolean | Promise<boolean>;
     private resolveRead: ((value?: any) => void) | undefined;
-    private proxy?: ProxyInterface;
+    private proxy?: SocksProxyType;
 
     constructor(proxy?: ProxyInterface) {
         this.client = undefined;
         this.closed = true;
         this.stream = Buffer.alloc(0);
-        if (!proxy?.MTProxy) {
+        if (proxy) {
             // we only want to use this when it's not an MTProto proxy.
-            if (proxy) {
+            if (!('MTProxy' in proxy)) {
                 if (!proxy.ip || !proxy.port || !proxy.socksType) {
                     throw new Error(
-                        `Invalid sockets params. ${proxy.ip}, ${proxy.port}, ${proxy.socksType}`
+                        `Invalid sockets params: ip=${proxy.ip}, port=${proxy.port}, socksType=${proxy.socksType}`
                     );
                 }
+                this.proxy = proxy;
             }
-            this.proxy = proxy;
         }
     }
 
@@ -90,10 +90,7 @@ export class PromisedNetSockets {
                 proxy: {
                     host: this.proxy.ip,
                     port: this.proxy.port,
-                    type:
-                        this.proxy.socksType != undefined
-                            ? this.proxy.socksType
-                            : 5, // Proxy version (4 or 5)
+                    type: this.proxy.socksType,
                     userId: this.proxy.username,
                     password: this.proxy.password,
                 },

--- a/gramjs/network/connection/TCPMTProxy.ts
+++ b/gramjs/network/connection/TCPMTProxy.ts
@@ -8,16 +8,22 @@ import {
 } from "../../extensions";
 import { CTR } from "../../crypto/CTR";
 
-export interface ProxyInterface {
-    socksType?: 4 | 5;
+interface BasicProxyInterface {
     ip: string;
     port: number;
-    secret?: string;
-    MTProxy?: boolean;
     timeout?: number;
     username?: string;
     password?: string;
 }
+export type MTProxyType = BasicProxyInterface & {
+    secret: string;
+    MTProxy: true;
+}
+export type SocksProxyType = BasicProxyInterface & {
+    socksType: 4 | 5;
+}
+
+export type ProxyInterface = MTProxyType | SocksProxyType;
 
 class MTProxyIO {
     header?: Buffer = undefined;
@@ -154,7 +160,7 @@ export class TCPMTProxy extends ObfuscatedConnection {
             proxy: proxy,
             testServers: testServers,
         });
-        if (!proxy.MTProxy) {
+        if (!('MTProxy' in proxy)) {
             throw new Error("This connection only supports MPTProxies");
         }
         if (!proxy.secret) {


### PR DESCRIPTION
To avoid possible misunderstanding of proxy usage.
For example, initial proxy interface allows non-mtproto proxy without socksType. But it's not possible to use the library with proxy without socksType. Also the library does not support HTTP proxy. 

So the changes might help to understand it.