### PR TITLE
Add option to override localStorage in StoreSession

### DIFF
--- a/gramjs/sessions/StoreSession.ts
+++ b/gramjs/sessions/StoreSession.ts
@@ -7,21 +7,21 @@ export class StoreSession extends MemorySession {
     private readonly sessionName: string;
     private store: StoreBase;
 
-    constructor(sessionName: string, divider = ":") {
+    constructor(sessionName: string, divider = ":", localStorageGiven = localStorage) {
         super();
         if (sessionName === "session") {
             throw new Error(
                 "Session name can't be 'session'. Please use a different name."
             );
         }
-        if (typeof localStorage === "undefined" || localStorage === null) {
+        if (typeof localStorageGiven === "undefined" || localStorageGiven === null) {
             const LocalStorage = require("./localStorage").LocalStorage;
             this.store = store.area(
                 sessionName,
                 new LocalStorage("./" + sessionName)
             );
         } else {
-            this.store = store.area(sessionName, localStorage);
+            this.store = store.area(sessionName, localStorageGiven);
         }
         if (divider == undefined) {
             divider = ":";


### PR DESCRIPTION
e.g. I'm running inside deno and I'd like not to use their implementation (as I cannot easily control the storage path):
```js
new StoreSession('tg-data', ':', null)
```