### PR TITLE
Export events like you export another things

### DIFF
--- a/gramjs/events/index.ts
+++ b/gramjs/events/index.ts
@@ -1,2 +1,6 @@
 export { Raw } from "./Raw";
 export { NewMessage, NewMessageEvent } from "./NewMessage";
+export { EditedMessage, EditedMessageEvent } from "./EditedMessage";
+export { DeletedMessage, DeletedMessageEvent } from "./DeletedMessage";
+export { CallbackQuery, CallbackQueryEvent } from "./CallbackQuery";
+export { Album, AlbumEvent } from "./Album";

--- a/gramjs/index.ts
+++ b/gramjs/index.ts
@@ -1,15 +1,27 @@
 export { Api } from "./tl";
 import * as tl from "./tl";
+
 export { TelegramClient } from "./client/TelegramClient";
 export { Connection } from "./network";
 export { version } from "./Version";
 export { Logger } from "./extensions/Logger";
 import * as utils from "./Utils";
 import * as errors from "./errors";
+import * as events from "./events";
 import * as sessions from "./sessions";
 import * as extensions from "./extensions";
 import * as helpers from "./Helpers";
 import * as client from "./client";
 import * as password from "./Password";
 
-export { utils, errors, sessions, extensions, helpers, tl, password, client };
+export {
+    utils,
+    errors,
+    events,
+    sessions,
+    extensions,
+    helpers,
+    tl,
+    password,
+    client,
+};


### PR DESCRIPTION
#698 #601 

Even I try to make import as you wrote in you documentation

```js
import { TelegramClient } from "telegram";
import { StringSession } from "telegram/sessions";
import { NewMessageEvent } from "telegram/events";
```

I have problem with exports and **ERR_UNSUPPORTED_DIR_IMPORT**

So please inject events into main exported object.

It will fix many problems with Events as minimum.

Thanx!