### PR TITLE
Disable type checking in Jest to unblock test execution

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,7 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 module.exports = {
-  preset: "ts-jest",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { isolatedModules: true }],
+  },
   testEnvironment: "node",
 };


### PR DESCRIPTION
There appears to be an obscure issue in ts-jest with the `setTimeout` types, as the same files are type-checked correctly by `tsc` from the command line. As a simple way to unblock testing, this PR disables type checking in Jest. If type checking in CI is needed, `tsc` can be run as a separate command.