### PR TITLE
Fix parse invite link

### DIFF
--- a/gramjs/client/messageParse.ts
+++ b/gramjs/client/messageParse.ts
@@ -69,7 +69,7 @@ export async function _parseMessageText(
     for (let i = msgEntities.length - 1; i >= 0; i--) {
         const e = msgEntities[i];
         if (e instanceof Api.MessageEntityTextUrl) {
-            const m = /^@|\+|tg:\/\/user\?id=(\d+)/.exec(e.url);
+            const m = /^@|tg:\/\/user\?id=(\d+)/.exec(e.url);
             if (m) {
                 const userIdOrUsername = m[1] ? Number(m[1]) : e.url;
                 const isMention = await _replaceWithMention(


### PR DESCRIPTION
Invitation links to the channel start with t.me/+XXX , which is why the regular expression does not skip the entity and the link disappears from the message

```typescript
client.sendMessage("me", { message: '<a href="https://t.me/+r20zmz3fQyv2YWUy">Link</a>', parseMode: 'html' })
```