### PR TITLE
fix: export all event classes from events/index.ts

### DIFF
--- a/gramjs/events/index.ts
+++ b/gramjs/events/index.ts
@@ -1,2 +1,6 @@
 export { Raw } from "./Raw";
 export { NewMessage, NewMessageEvent } from "./NewMessage";
+export { EditedMessage, EditedMessageEvent } from "./EditedMessage";
+export { DeletedMessage, DeletedMessageEvent } from "./DeletedMessage";
+export { Album, AlbumEvent } from "./Album";
+export { CallbackQuery, CallbackQueryEvent } from "./CallbackQuery";


### PR DESCRIPTION
The events barrel file (`gramjs/events/index.ts`) only exported `Raw` and `NewMessage`, but `EditedMessage`, `DeletedMessage`, `Album`, and `CallbackQuery` (along with their event classes) were missing.

This meant users had to use deep imports like:
```ts
const { EditedMessage } = require('telegram/events/EditedMessage');
```

instead of the expected:
```ts
const { EditedMessage } = require('telegram/events');
```

This PR adds the missing re-exports.

Fixes #811