### PR TITLE
fix(RequestIter): clamp waitTime sleep to prevent negative setTimeout…

### DIFF
--- a/gramjs/requestIter.ts
+++ b/gramjs/requestIter.ts
@@ -66,6 +66,13 @@ export class RequestIter implements AsyncIterable<any> {
                             this.waitTime -
                                 (new Date().getTime() / 1000 - this.lastLoad)
                         );
+                        await sleep(
+                            Math.max(
+                                0, 
+                                this.waitTime - 
+                                    (new Date().getTime() / 1000 - this.lastLoad)
+                            )
+                        );
                     }
                     this.lastLoad = new Date().getTime() / 1000;
                     this.index = 0;


### PR DESCRIPTION
… delay

When a chunk takes longer to load than `waitTime`, the expression `waitTime - elapsed` produces a negative value, causing Node.js to emit a `TimeoutNegativeWarning`. Wrap the argument with `Math.max(0, ...)` to ensure the delay is never negative.