### PR TITLE
Add sendAs option to client.sendMessage

### DIFF
--- a/__tests__/client/sendMessage.spec.ts
+++ b/__tests__/client/sendMessage.spec.ts
@@ -1,0 +1,51 @@
+import bigInt from "big-integer";
+import { sendMessage } from "../../gramjs/client/messages";
+import { Api } from "../../gramjs/tl/api";
+
+describe("sendMessage", () => {
+    const buildStubClient = () => {
+        const sendAsPeer = new Api.InputPeerChannel({
+            channelId: bigInt(99),
+            accessHash: bigInt(1),
+        });
+        const targetPeer = new Api.InputPeerSelf();
+        let captured: any;
+        const client: any = {
+            parseMode: undefined,
+            getInputEntity: jest.fn(async (e: any) =>
+                e === "channel-handle" ? sendAsPeer : targetPeer
+            ),
+            invoke: jest.fn(async (req: any) => {
+                captured = req;
+                return {} as any;
+            }),
+            buildReplyMarkup: () => undefined,
+            _getResponseMessage: () => undefined,
+        };
+        return { client, sendAsPeer, targetPeer, getCaptured: () => captured };
+    };
+
+    test("forwards resolved sendAs InputPeer onto Api.messages.SendMessage", async () => {
+        const { client, sendAsPeer, getCaptured } = buildStubClient();
+
+        await sendMessage(client, "me", {
+            message: "hi",
+            sendAs: "channel-handle",
+        });
+
+        expect(client.getInputEntity).toHaveBeenCalledWith("channel-handle");
+        const req = getCaptured();
+        expect(req).toBeInstanceOf(Api.messages.SendMessage);
+        expect(req.sendAs).toBe(sendAsPeer);
+    });
+
+    test("leaves sendAs undefined when option not provided", async () => {
+        const { client, getCaptured } = buildStubClient();
+
+        await sendMessage(client, "me", { message: "hi" });
+
+        const req = getCaptured();
+        expect(req).toBeInstanceOf(Api.messages.SendMessage);
+        expect(req.sendAs).toBeUndefined();
+    });
+});

--- a/gramjs/client/messages.ts
+++ b/gramjs/client/messages.ts
@@ -523,6 +523,13 @@ export interface SendMessageParams {
      * Used for threads to reply to a specific thread
      */
     topMsgId?: number | Api.Message;
+    /**
+     * Send the message on behalf of another peer (e.g. a linked channel or an
+     * anonymous-admin identity). Maps to `send_as` on `messages.sendMessage`.
+     * The current account must be allowed to post as the given peer
+     * (use `channels.getSendAs` to enumerate valid options).
+     */
+    sendAs?: EntityLike;
 }
 
 /** interface used for forwarding messages */
@@ -711,6 +718,7 @@ export async function sendMessage(
         noforwards,
         commentTo,
         topMsgId,
+        sendAs,
     }: SendMessageParams = {}
 ) {
     if (file) {
@@ -738,6 +746,8 @@ export async function sendMessage(
         });
     }
     entity = await client.getInputEntity(entity);
+    const sendAsPeer =
+        sendAs != undefined ? await client.getInputEntity(sendAs) : undefined;
     if (commentTo != undefined) {
         const discussionData = await getCommentData(client, entity, commentTo);
         entity = discussionData.entity;
@@ -787,6 +797,7 @@ export async function sendMessage(
             noWebpage: !(message.media instanceof Api.MessageMediaWebPage),
             scheduleDate: schedule,
             noforwards: noforwards,
+            sendAs: sendAsPeer,
         });
         message = message.message;
     } else {
@@ -814,6 +825,7 @@ export async function sendMessage(
             replyMarkup: client.buildReplyMarkup(buttons),
             scheduleDate: schedule,
             noforwards: noforwards,
+            sendAs: sendAsPeer,
         });
     }
     const result = await client.invoke(request);


### PR DESCRIPTION
Closes #827.

## Summary
Exposes the `send_as` parameter (already present on `messages.sendMessage` since
layer 167) through the high-level `client.sendMessage` wrapper, so callers no
longer need to drop down to `client.invoke(new Api.messages.SendMessage(...))`
just to post on behalf of a linked channel or anonymous-admin identity.

## Changes
- `gramjs/client/messages.ts`
  - Add `sendAs?: EntityLike` to `SendMessageParams` with JSDoc.
  - Resolve it via `client.getInputEntity(sendAs)` alongside the target entity.
  - Forward the resolved `InputPeer` to both `Api.messages.SendMessage`
    constructions (the `Api.Message`-resend branch and the fresh-text branch).
- `__tests__/client/sendMessage.spec.ts` (new)
  - Two specs against a stub `TelegramClient`: (1) asserts `sendAs` is resolved
    and forwarded onto the constructed request, (2) asserts the field is left
    `undefined` when the option is omitted.

## Scope
Limited to the no-file path. The `file` branch delegates to `client.sendFile`,
which would need a separate change to thread `sendAs` through `messages.SendMedia`.

## Test plan
- [x] `npx jest __tests__/client/sendMessage.spec.ts` — both specs pass locally.
- [ ] Manual smoke test against a Telegram account with permission to post as a
      linked channel.