### PR TITLE
Normalize tg://user?id=<username> hrefs so _parseMessageText can resolve them

### DIFF
--- a/__tests__/extensions/HTML.spec.ts
+++ b/__tests__/extensions/HTML.spec.ts
@@ -1,3 +1,4 @@
+import bigInt from "big-integer";
 import { HTMLParser } from "../../gramjs/extensions/html";
 import { Api as types } from "../../gramjs/tl/api";
 
@@ -69,6 +70,81 @@ describe("HTMLParser", () => {
       expect(entities[0]).toBeInstanceOf(types.MessageEntityItalic);
       expect(entities[1]).toBeInstanceOf(types.MessageEntityBold);
     });
+
+    test("it should parse tg://user?id mention with numeric id as MessageEntityMentionName", () => {
+      const [text, entities] = HTMLParser.parse(
+        'Hello <a href="tg://user?id=123456789">name</a>'
+      );
+      expect(text).toEqual("Hello name");
+      expect(entities.length).toEqual(1);
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      const mention = entities[0] as types.MessageEntityMentionName;
+      expect(mention.userId.toString()).toEqual("123456789");
+      expect(mention.offset).toEqual(6);
+      expect(mention.length).toEqual(4);
+    });
+
+    test("it should parse tg://user?id mention with very large numeric id (long)", () => {
+      const bigId = "12345678901234567890";
+      const [text, entities] = HTMLParser.parse(
+        `<a href="tg://user?id=${bigId}">u</a>`
+      );
+      expect(text).toEqual("u");
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      const mention = entities[0] as types.MessageEntityMentionName;
+      expect(mention.userId.toString()).toEqual(bigId);
+    });
+
+    test("it should ignore extra query params after the mention id", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=42&foo=bar">x</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      expect(
+        (entities[0] as types.MessageEntityMentionName).userId.toString()
+      ).toEqual("42");
+    });
+
+    test("it should fall back to TextUrl when the mention id is not numeric", () => {
+      const [text, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=alice">alice</a>'
+      );
+      expect(text).toEqual("alice");
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      const fallback = entities[0] as types.MessageEntityTextUrl;
+      expect(fallback.url).toEqual("tg://user?id=alice");
+      expect(fallback.offset).toEqual(0);
+      expect(fallback.length).toEqual(5);
+    });
+
+    test("it should parse mention containing nested formatting", () => {
+      const [text, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=42"><strong>name</strong></a>'
+      );
+      expect(text).toEqual("name");
+      expect(entities.length).toEqual(2);
+      const bold = entities.find(
+        (e) => e instanceof types.MessageEntityBold
+      ) as types.MessageEntityBold;
+      const mention = entities.find(
+        (e) => e instanceof types.MessageEntityMentionName
+      ) as types.MessageEntityMentionName;
+      expect(bold).toBeDefined();
+      expect(mention).toBeDefined();
+      expect(mention.userId.toString()).toEqual("42");
+      expect(mention.offset).toEqual(0);
+      expect(mention.length).toEqual(4);
+      expect(bold.offset).toEqual(0);
+      expect(bold.length).toEqual(4);
+    });
+
+    test("it should fall back to TextUrl when the mention id is empty", () => {
+      const [, entities] = HTMLParser.parse('<a href="tg://user?id=">x</a>');
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id="
+      );
+    });
   });
 
   describe(".unparse", () => {
@@ -101,6 +177,28 @@ describe("HTMLParser", () => {
       ];
       const text = HTMLParser.unparse(strippedText, rawEntities);
       expect(text).toEqual(unparsed);
+    });
+  });
+
+  describe("mention round-trip", () => {
+    test("entities → unparse → parse should preserve MessageEntityMentionName", () => {
+      const original = [
+        new types.MessageEntityMentionName({
+          offset: 0,
+          length: 4,
+          userId: bigInt("123456789"),
+        }),
+      ];
+      const html = HTMLParser.unparse("name", original);
+      expect(html).toEqual('<a href="tg://user?id=123456789">name</a>');
+      const [text, parsed] = HTMLParser.parse(html);
+      expect(text).toEqual("name");
+      expect(parsed.length).toEqual(1);
+      expect(parsed[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      const mention = parsed[0] as types.MessageEntityMentionName;
+      expect(mention.userId.toString()).toEqual("123456789");
+      expect(mention.offset).toEqual(0);
+      expect(mention.length).toEqual(4);
     });
   });
 });

--- a/__tests__/extensions/HTML.spec.ts
+++ b/__tests__/extensions/HTML.spec.ts
@@ -235,11 +235,10 @@ describe("HTMLParser", () => {
 
     test.each([
       ["+123", "tg://user?id=+123"],
-      ["0123", "tg://user?id=0123"],
       ["1e5", "tg://user?id=1e5"],
       [" 42 ", "tg://user?id= 42 "],
     ])(
-      "it should not accept laundered numeric form %s as a mention",
+      "it should not accept non-canonical numeric form %s as a mention",
       (_id, fullUrl) => {
         const [, entities] = HTMLParser.parse(`<a href="${fullUrl}">x</a>`);
         expect(entities[0]).not.toBeInstanceOf(

--- a/__tests__/extensions/HTML.spec.ts
+++ b/__tests__/extensions/HTML.spec.ts
@@ -105,16 +105,46 @@ describe("HTMLParser", () => {
       ).toEqual("42");
     });
 
-    test("it should fall back to TextUrl when the mention id is not numeric", () => {
+    test("it should parse tg://user?id mention with negative numeric id (channel/group)", () => {
+      const [text, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=-1001234567890">channel</a>'
+      );
+      expect(text).toEqual("channel");
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      const mention = entities[0] as types.MessageEntityMentionName;
+      expect(mention.userId.toString()).toEqual("-1001234567890");
+    });
+
+    test("it should map alphanumeric mention id to TextUrl with @-prefixed username", () => {
       const [text, entities] = HTMLParser.parse(
         '<a href="tg://user?id=alice">alice</a>'
       );
       expect(text).toEqual("alice");
       expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
       const fallback = entities[0] as types.MessageEntityTextUrl;
-      expect(fallback.url).toEqual("tg://user?id=alice");
+      expect(fallback.url).toEqual("@alice");
       expect(fallback.offset).toEqual(0);
       expect(fallback.length).toEqual(5);
+    });
+
+    test("it should not double the @ when the alphanumeric id already starts with one", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=@alice">alice</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "@alice"
+      );
+    });
+
+    test("it should strip extra query params from alphanumeric mention id too", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=alice&foo=bar">alice</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "@alice"
+      );
     });
 
     test("it should parse mention containing nested formatting", () => {
@@ -145,6 +175,78 @@ describe("HTMLParser", () => {
         "tg://user?id="
       );
     });
+
+    test("it should preserve original URL when alphanumeric id is too short to be a username", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=ab">ab</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=ab"
+      );
+    });
+
+    test("it should preserve original URL when alphanumeric id is too long to be a username", () => {
+      const longId = "a".repeat(33);
+      const [, entities] = HTMLParser.parse(
+        `<a href="tg://user?id=${longId}">x</a>`
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        `tg://user?id=${longId}`
+      );
+    });
+
+    test("it should preserve original URL when alphanumeric id has no letter or number", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=______">x</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=______"
+      );
+    });
+
+    test("it should preserve original URL on double @ in alphanumeric id", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=@@alice">x</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=@@alice"
+      );
+    });
+
+    test("it should preserve original URL on lone @", () => {
+      const [, entities] = HTMLParser.parse('<a href="tg://user?id=@">x</a>');
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=@"
+      );
+    });
+
+    test("it should preserve original URL on lone minus sign", () => {
+      const [, entities] = HTMLParser.parse('<a href="tg://user?id=-">x</a>');
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=-"
+      );
+    });
+
+    test.each([
+      ["+123", "tg://user?id=+123"],
+      ["0123", "tg://user?id=0123"],
+      ["1e5", "tg://user?id=1e5"],
+      [" 42 ", "tg://user?id= 42 "],
+    ])(
+      "it should not accept laundered numeric form %s as a mention",
+      (_id, fullUrl) => {
+        const [, entities] = HTMLParser.parse(`<a href="${fullUrl}">x</a>`);
+        expect(entities[0]).not.toBeInstanceOf(
+          types.MessageEntityMentionName
+        );
+      }
+    );
   });
 
   describe(".unparse", () => {
@@ -199,6 +301,26 @@ describe("HTMLParser", () => {
       expect(mention.userId.toString()).toEqual("123456789");
       expect(mention.offset).toEqual(0);
       expect(mention.length).toEqual(4);
+    });
+
+    test("entities → unparse → parse should preserve a negative MessageEntityMentionName id", () => {
+      const original = [
+        new types.MessageEntityMentionName({
+          offset: 0,
+          length: 7,
+          userId: bigInt("-1001234567890"),
+        }),
+      ];
+      const html = HTMLParser.unparse("channel", original);
+      expect(html).toEqual(
+        '<a href="tg://user?id=-1001234567890">channel</a>'
+      );
+      const [text, parsed] = HTMLParser.parse(html);
+      expect(text).toEqual("channel");
+      expect(parsed[0]).toBeInstanceOf(types.MessageEntityMentionName);
+      expect(
+        (parsed[0] as types.MessageEntityMentionName).userId.toString()
+      ).toEqual("-1001234567890");
     });
   });
 });

--- a/__tests__/extensions/HTML.spec.ts
+++ b/__tests__/extensions/HTML.spec.ts
@@ -1,4 +1,3 @@
-import bigInt from "big-integer";
 import { HTMLParser } from "../../gramjs/extensions/html";
 import { Api as types } from "../../gramjs/tl/api";
 
@@ -71,63 +70,19 @@ describe("HTMLParser", () => {
       expect(entities[1]).toBeInstanceOf(types.MessageEntityBold);
     });
 
-    test("it should parse tg://user?id mention with numeric id as MessageEntityMentionName", () => {
-      const [text, entities] = HTMLParser.parse(
-        'Hello <a href="tg://user?id=123456789">name</a>'
-      );
-      expect(text).toEqual("Hello name");
-      expect(entities.length).toEqual(1);
-      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      const mention = entities[0] as types.MessageEntityMentionName;
-      expect(mention.userId.toString()).toEqual("123456789");
-      expect(mention.offset).toEqual(6);
-      expect(mention.length).toEqual(4);
-    });
-
-    test("it should parse tg://user?id mention with very large numeric id (long)", () => {
-      const bigId = "12345678901234567890";
-      const [text, entities] = HTMLParser.parse(
-        `<a href="tg://user?id=${bigId}">u</a>`
-      );
-      expect(text).toEqual("u");
-      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      const mention = entities[0] as types.MessageEntityMentionName;
-      expect(mention.userId.toString()).toEqual(bigId);
-    });
-
-    test("it should ignore extra query params after the mention id", () => {
-      const [, entities] = HTMLParser.parse(
-        '<a href="tg://user?id=42&foo=bar">x</a>'
-      );
-      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      expect(
-        (entities[0] as types.MessageEntityMentionName).userId.toString()
-      ).toEqual("42");
-    });
-
-    test("it should parse tg://user?id mention with negative numeric id (channel/group)", () => {
-      const [text, entities] = HTMLParser.parse(
-        '<a href="tg://user?id=-1001234567890">channel</a>'
-      );
-      expect(text).toEqual("channel");
-      expect(entities[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      const mention = entities[0] as types.MessageEntityMentionName;
-      expect(mention.userId.toString()).toEqual("-1001234567890");
-    });
-
-    test("it should map alphanumeric mention id to TextUrl with @-prefixed username", () => {
+    test("it should rewrite tg://user?id=<username> to TextUrl with @-prefixed username", () => {
       const [text, entities] = HTMLParser.parse(
         '<a href="tg://user?id=alice">alice</a>'
       );
       expect(text).toEqual("alice");
       expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
-      const fallback = entities[0] as types.MessageEntityTextUrl;
-      expect(fallback.url).toEqual("@alice");
-      expect(fallback.offset).toEqual(0);
-      expect(fallback.length).toEqual(5);
+      const e = entities[0] as types.MessageEntityTextUrl;
+      expect(e.url).toEqual("@alice");
+      expect(e.offset).toEqual(0);
+      expect(e.length).toEqual(5);
     });
 
-    test("it should not double the @ when the alphanumeric id already starts with one", () => {
+    test("it should not double the @ when the id already starts with one", () => {
       const [, entities] = HTMLParser.parse(
         '<a href="tg://user?id=@alice">alice</a>'
       );
@@ -137,7 +92,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should strip extra query params from alphanumeric mention id too", () => {
+    test("it should strip extra query params from the username", () => {
       const [, entities] = HTMLParser.parse(
         '<a href="tg://user?id=alice&foo=bar">alice</a>'
       );
@@ -147,28 +102,27 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should parse mention containing nested formatting", () => {
-      const [text, entities] = HTMLParser.parse(
-        '<a href="tg://user?id=42"><strong>name</strong></a>'
+    test("it should keep the original tg://user?id URL when the id is numeric so _parseMessageText can resolve it", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=123456789">name</a>'
       );
-      expect(text).toEqual("name");
-      expect(entities.length).toEqual(2);
-      const bold = entities.find(
-        (e) => e instanceof types.MessageEntityBold
-      ) as types.MessageEntityBold;
-      const mention = entities.find(
-        (e) => e instanceof types.MessageEntityMentionName
-      ) as types.MessageEntityMentionName;
-      expect(bold).toBeDefined();
-      expect(mention).toBeDefined();
-      expect(mention.userId.toString()).toEqual("42");
-      expect(mention.offset).toEqual(0);
-      expect(mention.length).toEqual(4);
-      expect(bold.offset).toEqual(0);
-      expect(bold.length).toEqual(4);
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=123456789"
+      );
     });
 
-    test("it should fall back to TextUrl when the mention id is empty", () => {
+    test("it should keep the original URL when the id has a leading minus", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=-1001234567890">x</a>'
+      );
+      expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
+      expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
+        "tg://user?id=-1001234567890"
+      );
+    });
+
+    test("it should preserve the URL when the id is empty", () => {
       const [, entities] = HTMLParser.parse('<a href="tg://user?id=">x</a>');
       expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
       expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
@@ -176,7 +130,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL when alphanumeric id is too short to be a username", () => {
+    test("it should preserve the URL when the username id is too short", () => {
       const [, entities] = HTMLParser.parse(
         '<a href="tg://user?id=ab">ab</a>'
       );
@@ -186,7 +140,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL when alphanumeric id is too long to be a username", () => {
+    test("it should preserve the URL when the username id is too long", () => {
       const longId = "a".repeat(33);
       const [, entities] = HTMLParser.parse(
         `<a href="tg://user?id=${longId}">x</a>`
@@ -197,7 +151,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL when alphanumeric id has no letter or number", () => {
+    test("it should preserve the URL when the username id has no letter or number", () => {
       const [, entities] = HTMLParser.parse(
         '<a href="tg://user?id=______">x</a>'
       );
@@ -207,7 +161,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL on double @ in alphanumeric id", () => {
+    test("it should preserve the URL on double @", () => {
       const [, entities] = HTMLParser.parse(
         '<a href="tg://user?id=@@alice">x</a>'
       );
@@ -217,7 +171,7 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL on lone @", () => {
+    test("it should preserve the URL on lone @", () => {
       const [, entities] = HTMLParser.parse('<a href="tg://user?id=@">x</a>');
       expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
       expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
@@ -225,27 +179,36 @@ describe("HTMLParser", () => {
       );
     });
 
-    test("it should preserve original URL on lone minus sign", () => {
-      const [, entities] = HTMLParser.parse('<a href="tg://user?id=-">x</a>');
+    test("it should keep the original URL when the username is all digits (handled by _parseMessageText)", () => {
+      const [, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=12345">x</a>'
+      );
       expect(entities[0]).toBeInstanceOf(types.MessageEntityTextUrl);
       expect((entities[0] as types.MessageEntityTextUrl).url).toEqual(
-        "tg://user?id=-"
+        "tg://user?id=12345"
       );
     });
 
-    test.each([
-      ["+123", "tg://user?id=+123"],
-      ["1e5", "tg://user?id=1e5"],
-      [" 42 ", "tg://user?id= 42 "],
-    ])(
-      "it should not accept non-canonical numeric form %s as a mention",
-      (_id, fullUrl) => {
-        const [, entities] = HTMLParser.parse(`<a href="${fullUrl}">x</a>`);
-        expect(entities[0]).not.toBeInstanceOf(
-          types.MessageEntityMentionName
-        );
-      }
-    );
+    test("it should rewrite the username href even when it wraps nested formatting", () => {
+      const [text, entities] = HTMLParser.parse(
+        '<a href="tg://user?id=alice"><strong>name</strong></a>'
+      );
+      expect(text).toEqual("name");
+      expect(entities.length).toEqual(2);
+      const bold = entities.find(
+        (e) => e instanceof types.MessageEntityBold
+      ) as types.MessageEntityBold;
+      const link = entities.find(
+        (e) => e instanceof types.MessageEntityTextUrl
+      ) as types.MessageEntityTextUrl;
+      expect(bold).toBeDefined();
+      expect(link).toBeDefined();
+      expect(link.url).toEqual("@alice");
+      expect(link.offset).toEqual(0);
+      expect(link.length).toEqual(4);
+      expect(bold.offset).toEqual(0);
+      expect(bold.length).toEqual(4);
+    });
   });
 
   describe(".unparse", () => {
@@ -278,48 +241,6 @@ describe("HTMLParser", () => {
       ];
       const text = HTMLParser.unparse(strippedText, rawEntities);
       expect(text).toEqual(unparsed);
-    });
-  });
-
-  describe("mention round-trip", () => {
-    test("entities → unparse → parse should preserve MessageEntityMentionName", () => {
-      const original = [
-        new types.MessageEntityMentionName({
-          offset: 0,
-          length: 4,
-          userId: bigInt("123456789"),
-        }),
-      ];
-      const html = HTMLParser.unparse("name", original);
-      expect(html).toEqual('<a href="tg://user?id=123456789">name</a>');
-      const [text, parsed] = HTMLParser.parse(html);
-      expect(text).toEqual("name");
-      expect(parsed.length).toEqual(1);
-      expect(parsed[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      const mention = parsed[0] as types.MessageEntityMentionName;
-      expect(mention.userId.toString()).toEqual("123456789");
-      expect(mention.offset).toEqual(0);
-      expect(mention.length).toEqual(4);
-    });
-
-    test("entities → unparse → parse should preserve a negative MessageEntityMentionName id", () => {
-      const original = [
-        new types.MessageEntityMentionName({
-          offset: 0,
-          length: 7,
-          userId: bigInt("-1001234567890"),
-        }),
-      ];
-      const html = HTMLParser.unparse("channel", original);
-      expect(html).toEqual(
-        '<a href="tg://user?id=-1001234567890">channel</a>'
-      );
-      const [text, parsed] = HTMLParser.parse(html);
-      expect(text).toEqual("channel");
-      expect(parsed[0]).toBeInstanceOf(types.MessageEntityMentionName);
-      expect(
-        (parsed[0] as types.MessageEntityMentionName).userId.toString()
-      ).toEqual("-1001234567890");
     });
   });
 });

--- a/gramjs/extensions/html.ts
+++ b/gramjs/extensions/html.ts
@@ -1,8 +1,10 @@
 import { Parser } from "htmlparser2";
 import { Handler } from "htmlparser2/lib/Parser";
-import bigInt from "big-integer";
 import { Api } from "../tl";
 import { helpers } from "../index";
+
+const ALL_DIGITS = /^\d+$/;
+const VALID_USERNAME = /^@?(?=.*[A-Za-z0-9])[A-Za-z0-9_]{5,32}$/;
 
 class HTMLToTelegramParser implements Handler {
     text: string;
@@ -79,13 +81,10 @@ class HTMLToTelegramParser implements Handler {
                 const rawId = url
                     .slice("tg://user?id=".length)
                     .split("&")[0];
-                if (/^-?\d+$/.test(rawId)) {
-                    EntityType = Api.MessageEntityMentionName;
-                    args["userId"] = bigInt(rawId);
-                    url = undefined;
-                } else if (
-                    /^@?(?=.*[A-Za-z0-9])[A-Za-z0-9_]{5,32}$/.test(rawId)
-                ) {
+                // Numeric ids are resolved later by _parseMessageText; only
+                // rewrite the username form (tg://user?id=<username>) into
+                // the @-prefixed url it knows how to look up.
+                if (!ALL_DIGITS.test(rawId) && VALID_USERNAME.test(rawId)) {
                     EntityType = Api.MessageEntityTextUrl;
                     args["url"] = rawId.startsWith("@")
                         ? rawId

--- a/gramjs/extensions/html.ts
+++ b/gramjs/extensions/html.ts
@@ -1,5 +1,6 @@
 import { Parser } from "htmlparser2";
 import { Handler } from "htmlparser2/lib/Parser";
+import bigInt from "big-integer";
 import { Api } from "../tl";
 import { helpers } from "../index";
 
@@ -74,6 +75,19 @@ class HTMLToTelegramParser implements Handler {
             if (url.startsWith("mailto:")) {
                 url = url.slice("mailto:".length, url.length);
                 EntityType = Api.MessageEntityEmail;
+            } else if (url.startsWith("tg://user?id=")) {
+                const rawId = url
+                    .slice("tg://user?id=".length)
+                    .split("&")[0];
+                if (/^\d+$/.test(rawId)) {
+                    EntityType = Api.MessageEntityMentionName;
+                    args["userId"] = bigInt(rawId);
+                    url = undefined;
+                } else {
+                    EntityType = Api.MessageEntityTextUrl;
+                    args["url"] = url;
+                    url = undefined;
+                }
             } else {
                 EntityType = Api.MessageEntityTextUrl;
                 args["url"] = url;

--- a/gramjs/extensions/html.ts
+++ b/gramjs/extensions/html.ts
@@ -79,20 +79,9 @@ class HTMLToTelegramParser implements Handler {
                 const rawId = url
                     .slice("tg://user?id=".length)
                     .split("&")[0];
-                let userId: ReturnType<typeof bigInt> | undefined;
-                if (rawId) {
-                    try {
-                        const parsed = bigInt(rawId);
-                        if (parsed.toString() === rawId) {
-                            userId = parsed;
-                        }
-                    } catch {
-                        userId = undefined;
-                    }
-                }
-                if (userId !== undefined) {
+                if (/^-?\d+$/.test(rawId)) {
                     EntityType = Api.MessageEntityMentionName;
-                    args["userId"] = userId;
+                    args["userId"] = bigInt(rawId);
                     url = undefined;
                 } else if (
                     /^@?(?=.*[A-Za-z0-9])[A-Za-z0-9_]{5,32}$/.test(rawId)

--- a/gramjs/extensions/html.ts
+++ b/gramjs/extensions/html.ts
@@ -79,9 +79,28 @@ class HTMLToTelegramParser implements Handler {
                 const rawId = url
                     .slice("tg://user?id=".length)
                     .split("&")[0];
-                if (/^\d+$/.test(rawId)) {
+                let userId: ReturnType<typeof bigInt> | undefined;
+                if (rawId) {
+                    try {
+                        const parsed = bigInt(rawId);
+                        if (parsed.toString() === rawId) {
+                            userId = parsed;
+                        }
+                    } catch {
+                        userId = undefined;
+                    }
+                }
+                if (userId !== undefined) {
                     EntityType = Api.MessageEntityMentionName;
-                    args["userId"] = bigInt(rawId);
+                    args["userId"] = userId;
+                    url = undefined;
+                } else if (
+                    /^@?(?=.*[A-Za-z0-9])[A-Za-z0-9_]{5,32}$/.test(rawId)
+                ) {
+                    EntityType = Api.MessageEntityTextUrl;
+                    args["url"] = rawId.startsWith("@")
+                        ? rawId
+                        : "@" + rawId;
                     url = undefined;
                 } else {
                     EntityType = Api.MessageEntityTextUrl;


### PR DESCRIPTION
## Summary

Closes #831.

`_parseMessageText` (in `gramjs/client/messageParse.ts`) already converts `MessageEntityTextUrl` entities into mentions when the `url` field is either:
- `tg://user?id=<digits>` (positive numeric user id), or
- `@<username>` / `+<phone>` (username or phone-number reference).

So numeric ids are already handled end-to-end without changes to the HTML parser. What was missing: when `HTMLParser.parse` encountered `<a href="tg://user?id=<username>">…</a>`, the resulting `TextUrl.url` did not match the `_parseMessageText` regex and the mention was silently dropped.

This change normalizes only that case. When the id portion of `tg://user?id=` is a valid Telegram username (5-32 chars of `[A-Za-z0-9_]`, at least one letter or number, optionally prefixed with `@`), the HTML parser rewrites the entity URL to `@<username>` so `_parseMessageText` can resolve it. Everything else — numeric ids, negative ids, malformed values, empty values — is left untouched and passed through with the original `tg://user?id=…` URL.

A short comment in `html.ts` explains why the numeric branch is intentionally absent.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All existing `__tests__/extensions/HTML.spec.ts` tests still pass
- [x] New tests cover: bare username (`alice`), `@`-prefixed username (`@alice`), extra query params after the username, validation of length / character / `@` rules, all-digits ids passed through, negative ids passed through, empty id passed through, and a `<strong>` nested inside the username href